### PR TITLE
An example that correctly extracts the specs from '@spec'!

### DIFF
--- a/benchmarks/simple.ex
+++ b/benchmarks/simple.ex
@@ -1,0 +1,13 @@
+defmodule Addition do
+  @compile {:inline, ["add (overridable 1)": 2]}
+  use TypeCheck
+  spec add(number(), number()) :: number()
+  def add(a, b) do
+    a + b
+  end
+
+  def baseline_add(a, b) do
+    a + b
+  end
+end
+

--- a/benchmarks/simple.exs
+++ b/benchmarks/simple.exs
@@ -1,0 +1,14 @@
+Code.compile_file("benchmarks/simple.ex")
+
+as = Enum.to_list(1..10_000)
+bs = Enum.to_list(1..10_000)
+input_list = Enum.zip(as, bs)
+
+Benchee.run(
+  %{
+    "add with TypeCheck" => fn -> Enum.map(input_list, fn {a, b} -> Addition.add(a, b) end) end,
+    "baseline add" => fn -> Enum.map(input_list, fn {a, b} -> Addition.baseline_add(a, b) end) end,
+  },
+  time: 10,
+  memory_time: 2
+)

--- a/lib/example.ex
+++ b/lib/example.ex
@@ -1,0 +1,14 @@
+defmodule Example do
+  use TypeCheck
+  import Kernel, except: [@: 1]
+  require TypeCheck.Macros
+  import TypeCheck.Macros, only: [@: 1]
+
+  @type myint :: integer()
+
+  @doc "Does this documentation show up?"
+  @spec add(integer(), integer()) :: myint()
+  def add(a, b) do
+    a + b
+  end
+end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -26,6 +26,23 @@ defmodule TypeCheck.Spec do
   end
 
   @doc false
+  def create_spec_def(name, arity, params_ast, return_type_ast) do
+    spec_fun_name = :"__type_check_spec_for_#{name}/#{arity}__"
+
+    quote location: :keep do
+      @doc false
+      def unquote(spec_fun_name)() do
+        # import TypeCheck.Builtin
+        %TypeCheck.Spec{
+          name: unquote(name),
+          param_types: unquote(params_ast),
+          return_type: unquote(return_type_ast)
+        }
+      end
+    end
+  end
+
+  @doc false
   def wrap_function_with_spec(name, line, arity, clean_params, params_spec_code, return_spec_code) do
     quote line: line do
       defoverridable([{unquote(name), unquote(arity)}])

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,7 @@ defmodule TypeCheck.MixProject do
       {:stream_data, "~> 0.5.0", optional: true},
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
+      {:benchee, "~> 1.0", only: :dev},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
   "earmark": {:hex, :earmark, "1.4.8", "a7d0b2a02d52ffd5ca73106f36cd7f7db333ded41c756f1f1407adadbeef9bb7", [:mix], [{:earmark_parser, ">= 1.4.9", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "138d6a1de01e14e33c6762a245829d7d413d63b6d49d55c0232bbc6a561127ba"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.9", "819bda2049e6ee1365424e4ced1ba65806eacf0d2867415f19f3f80047f8037b", [:mix], [], "hexpm", "8bf54fddabf2d7e137a0c22660e71b49d5a0a82d1fb05b5af62f2761cd6485c4"},


### PR DESCRIPTION
It also does not break the documentation :-D.


Related to #17 .
Before this can be merged, we definitely need the following:
1. An option added to `use TypeCheck` that enables this behaviour. Maybe `read_attributes: true` (defaults to false)?
2. An option added to `use TypeCheck` that explicitly _not_ writes types/specs to the type-attributes for when someone wants to customize them separately. Maybe `write_attributes: false` (defaults to true)?
3. Remove the example-file before merging.