### PR TITLE
builtin keyword type

### DIFF
--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -262,6 +262,36 @@ defmodule TypeCheck.Builtin do
 
   @doc typekind: :builtin
   @doc """
+  A list of pairs with atoms as 'keys' and anything allowed as as 'values'.
+
+  Shorthand for `list({atom(), any()})`
+
+      iex> x = [a: 1, b: 2]
+      iex> TypeCheck.conforms!(x, keyword())
+      [a: 1, b: 2]
+
+      iex> y = [a: 1, b: 2, 3]
+      iex> TypeCheck.conforms!(y, keyword())
+      ** (TypeCheck.TypeError) `[1, 2, 3.3]` does not check against `list({atom(), any()})`. Reason:
+        at index 2:
+          `3` is not a tuple.
+  """
+  def keyword() do
+    list(fixed_tuple([atom(), any()]))
+  end
+
+  @doc typekind: :builtin
+  @doc """
+  A list of pairs with atoms as 'keys' and t's as 'values'.
+
+  Shorthand for `list({atom(), t})`
+  """
+  def keyword(t) do
+    list(fixed_tuple([atom(), t]))
+  end
+
+  @doc typekind: :builtin
+  @doc """
   A module-function-arity tuple
 
   - Module is a `module/0`

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -270,11 +270,12 @@ defmodule TypeCheck.Builtin do
       iex> TypeCheck.conforms!(x, keyword())
       [a: 1, b: 2]
 
-      iex> y = [a: 1, b: 2, 3]
+      iex> y = [a: 1, b: 2] ++ [3, 4]
       iex> TypeCheck.conforms!(y, keyword())
-      ** (TypeCheck.TypeError) `[1, 2, 3.3]` does not check against `list({atom(), any()})`. Reason:
+      ** (TypeCheck.TypeError) `[{:a, 1}, {:b, 2}, 3, 4]` does not check against `list({atom(), any()})`. Reason:
         at index 2:
-          `3` is not a tuple.
+          `3` does not check against `{atom(), any()}`. Reason:
+            `3` is not a tuple.
   """
   def keyword() do
     list(fixed_tuple([atom(), any()]))

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -278,7 +278,7 @@ defmodule TypeCheck.Builtin do
             `3` is not a tuple.
   """
   def keyword() do
-    list(fixed_tuple([atom(), any()]))
+    keyword(any())
   end
 
   @doc typekind: :builtin


### PR DESCRIPTION
- Adds `keyword/0` and `keyword/1` as builtin types.
- Tests for the above.

Fixes #18 