### PR TITLE
Named types in specs

### DIFF
--- a/lib/example.ex
+++ b/lib/example.ex
@@ -1,9 +1,0 @@
-defmodule Example do
-  use TypeCheck
-  # @type! nice_num :: (x :: non_neg_integer() when x != 10)
-
-  @spec! in_magic_range((x :: non_neg_integer() when x != 42)) :: boolean()
-  def in_magic_range(val) do
-    true
-  end
-end

--- a/lib/example.ex
+++ b/lib/example.ex
@@ -1,0 +1,9 @@
+defmodule Example do
+  use TypeCheck
+  # @type! nice_num :: (x :: non_neg_integer() when x != 10)
+
+  @spec! in_magic_range((x :: non_neg_integer() when x != 42)) :: boolean()
+  def in_magic_range(val) do
+    true
+  end
+end

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -87,10 +87,10 @@ defmodule TypeCheck do
       iex> TypeCheck.conforms!({10, 20}, sorted_pair)
       {10, 20}
       iex> TypeCheck.conforms!({20, 10}, sorted_pair)
-      ** (TypeCheck.TypeError) `{20, 10}` does not check against `({lower :: number(), higher :: number()} when lower <= higher)`. Reason:
+      ** (TypeCheck.TypeError) `{20, 10}` does not check against `(sorted_pair :: {lower :: number(), higher :: number()} when lower <= higher)`. Reason:
         type guard:
           `lower <= higher` evaluated to false or nil.
-          bound values: %{higher: 10, lower: 20}
+          bound values: %{higher: 10, lower: 20, sorted_pair: {20, 10}}
 
   Named types are available in your guard even from the (both local and remote) types that you are using in your time, as long as those types are not defined as _opaque_ types.
 

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -77,9 +77,14 @@ defmodule TypeCheck.Macros do
     end
   end
 
-  defp create_spec_defs(specs, _definitions, _caller) do
+  defp create_spec_defs(specs, _definitions, caller) do
     for {name, _line, arity, _clean_params, params_ast, return_type_ast} <- specs do
-      TypeCheck.Spec.create_spec_def(name, arity, params_ast, return_type_ast)
+      require TypeCheck.Type
+
+      param_types = Enum.map(params_ast, &TypeCheck.Type.build_unescaped(&1, caller, true))
+      return_type = TypeCheck.Type.build_unescaped(return_type_ast, caller, true)
+
+      TypeCheck.Spec.create_spec_def(name, arity, param_types, return_type)
     end
   end
 
@@ -90,6 +95,7 @@ defmodule TypeCheck.Macros do
       end
 
       require TypeCheck.Type
+
       param_types = Enum.map(params_ast, &TypeCheck.Type.build_unescaped(&1, caller, true))
       return_type = TypeCheck.Type.build_unescaped(return_type_ast, caller, true)
 

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -273,12 +273,12 @@ defmodule TypeCheck.Macros do
   end
 
   defp define_type(
-         {:when, _, [{:"::", _, [name_with_maybe_params, type]}, guard_ast]},
+         {:when, _, [named_type = {:"::", _, [name_with_maybe_params, type]}, guard_ast]},
          kind,
          caller
        ) do
     define_type(
-      {:"::", [], [name_with_maybe_params, {:when, [], [type, guard_ast]}]},
+      {:"::", [], [name_with_maybe_params, {:when, [], [named_type, guard_ast]}]},
       kind,
       caller
     )

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -26,20 +26,22 @@ defmodule TypeCheck.Spec do
   end
 
   @doc false
-  def create_spec_def(name, arity, params_ast, return_type_ast) do
-    spec_fun_name = :"__type_check_spec_for_#{name}/#{arity}__"
+  def create_spec_def(name, arity, param_types, return_type) do
+    spec_fun_name = spec_fun_name(name, arity)
 
-    quote location: :keep do
+    res = quote location: :keep do
       @doc false
       def unquote(spec_fun_name)() do
         # import TypeCheck.Builtin
         %TypeCheck.Spec{
           name: unquote(name),
-          param_types: unquote(params_ast),
-          return_type: unquote(return_type_ast)
+          param_types: unquote(Macro.escape(param_types)),
+          return_type: unquote(Macro.escape(return_type))
         }
       end
     end
+    IO.puts(Macro.to_string(res))
+    res
   end
 
   @doc false

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -29,7 +29,7 @@ defmodule TypeCheck.Spec do
   def create_spec_def(name, arity, param_types, return_type) do
     spec_fun_name = spec_fun_name(name, arity)
 
-    res = quote location: :keep do
+    quote location: :keep do
       @doc false
       def unquote(spec_fun_name)() do
         # import TypeCheck.Builtin
@@ -40,8 +40,6 @@ defmodule TypeCheck.Spec do
         }
       end
     end
-    IO.puts(Macro.to_string(res))
-    res
   end
 
   @doc false

--- a/test/type_check_test.exs
+++ b/test/type_check_test.exs
@@ -6,9 +6,14 @@ end
 defmodule TypeCheckTest.SpecWithGuardExample do
   use TypeCheck
   @spec! in_magic_range((x :: non_neg_integer() when x != 42)) :: boolean()
-  def in_magic_range(val) do
+  def in_magic_range(_val) do
     true
   end
+end
+
+defmodule TypeCheckTest.TypeWithGuardExample do
+  use TypeCheck
+  @type! magic_num :: non_neg_integer() when magic_num != 69
 end
 
 
@@ -77,6 +82,14 @@ defmodule TypeCheckTest do
 
       assert {%TypeCheck.Spec{}, :param_error, %{}, [42]} = exception.raw
       assert {%TypeCheck.Builtin.Guarded{}, :guard_failed, %{}, 42} = elem(exception.raw, 2).problem
+    end
+  end
+
+  describe "type with guard" do
+    test "it can be conformed against" do
+      require TypeCheck
+      assert TypeCheck.conforms?(10, TypeCheckTest.TypeWithGuardExample.magic_num)
+      refute TypeCheck.conforms?(69, TypeCheckTest.TypeWithGuardExample.magic_num)
     end
   end
 end


### PR DESCRIPTION
C.f. https://elixirforum.com/t/typecheck-fast-and-flexible-runtime-type-checking-for-your-elixir-projects/32886/17?u=qqwy

Turns out there was a bit of the implementation that needed cleaning up. Not it works as expected:

- You can now freely write types with guards referring the type itself like `@type! mything :: some_other_type() when mything > 42`
- You can use the same syntax inside a spec, like: `@spec! div(x :: number, y :: number when y != 0) :: number()`