### PR TITLE
Makes sure that TypeCheck compiles for Elixir 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
     - otp_release: 22.0
       elixir: 1.11
     - otp_release: 23.0
-      elixir: 1.9
-    - otp_release: 23.0
       elixir: 1.10
     - otp_release: 23.0
       elixir: 1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ matrix:
       elixir: 1.9
     - otp_release: 22.0
       elixir: 1.10
+    - otp_release: 22.0
+      elixir: 1.11
+    - otp_release: 23.0
+      elixir: 1.9
+    - otp_release: 23.0
+      elixir: 1.10
+    - otp_release: 23.0
+      elixir: 1.11
 
 cache:
   directories:

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -382,11 +382,6 @@ defmodule TypeCheck.Builtin do
     |> Map.put(:value, value)
   end
 
-  @doc false
-  def left | right do
-    one_of(left, right)
-  end
-
   @doc typekind: :builtin
   @doc """
   A union of multiple types (also known as a 'sum type')

--- a/mix.exs
+++ b/mix.exs
@@ -48,9 +48,9 @@ defmodule TypeCheck.MixProject do
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
       {:stream_data, "~> 0.5.0", optional: true},
-      {:ex_doc, "~> 0.22", only: :dev, runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
-      {:benchee, "~> 1.0", only: :dev},
+      {:ex_doc, "~> 0.22", only: :docs, runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dialize], runtime: false},
+      {:benchee, "~> 1.0", only: :bench},
     ]
   end
 


### PR DESCRIPTION
Fixes #28 by making sure `|` is no longer used as a function name because in Elixir 1.11 it now is explicitly a special form.