### PR TITLE
Support unquote fragments in `test!`, `spec!` and co.

### DIFF
--- a/test/type_check/macros_test.exs
+++ b/test/type_check/macros_test.exs
@@ -31,8 +31,6 @@ defmodule TypeCheck.MacrosTest do
       defmodule UnquoteFragmentSpec do
         defmacro my_macro(name) do
           quote bind_quoted: [name: name], location: :keep do
-
-            use TypeCheck
             spec! unquote(:"my_function_#{name}")(binary) :: binary
             def unquote(:"my_function_#{name}")(greeting) do
               greeting
@@ -42,6 +40,7 @@ defmodule TypeCheck.MacrosTest do
       end
 
       defmodule UnquoteFragmentSpecExample do
+        use TypeCheck
         require UnquoteFragmentSpec
 
         UnquoteFragmentSpec.my_macro("greeter")

--- a/test/type_check/macros_test.exs
+++ b/test/type_check/macros_test.exs
@@ -26,5 +26,32 @@ defmodule TypeCheck.MacrosTest do
         assert Enum.all?(x, fn elem -> is_integer(elem) end)
       end
     end
+
+    test "support unquote fragments" do
+      defmodule UnquoteFragmentSpec do
+        defmacro my_macro(name) do
+          quote bind_quoted: [name: name], location: :keep do
+
+            use TypeCheck
+            spec! unquote(:"my_function_#{name}")(binary) :: binary
+            def unquote(:"my_function_#{name}")(greeting) do
+              greeting
+            end
+          end
+        end
+      end
+
+      defmodule UnquoteFragmentSpecExample do
+        require UnquoteFragmentSpec
+
+        UnquoteFragmentSpec.my_macro("greeter")
+      end
+
+      assert TypeCheck.Spec.defined?(UnquoteFragmentSpecExample, :my_function_greeter, 1)
+      assert UnquoteFragmentSpecExample.my_function_greeter("hi") == "hi"
+      assert_raise(TypeCheck.TypeError, fn ->
+        UnquoteFragmentSpecExample.my_function_greeter(1)
+      end)
+    end
   end
 end


### PR DESCRIPTION
Fixes #36

I found out that Elixir itself allows unquote fragments in specs by doing some indirection juggling between quote, unquote and `Macro.escape(... unquote: true)`.

This will allow people to use TypeCheck's functionality even inside macros for e.g. functions or types whose names are dynamic.

It does still require people to use `spec!`, rather than `@spec!` (etc.) in a quoted context for some reason. I'll open a separate issue for that, as it seems more involved to resolve that problem.