### PR TITLE
52 enable runtime checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Details:
 - [x] Manually overriding generators for user-specified types if so desired.
 - [x] Creating generators from specs
   - [x] Wrap spec-generators so you have a single statement to call in the test suite which will prop-test your function against all allowed inputs/outputs.
+- [x] Option to turn the generation of runtime checks off for a given module in a particular environment (`enable_runtime_checks`).
 - [ ] Overrides for builtin remote types (`String.t`,`Enum.t`, `Range.t`, `MapSet.t` etc.) **(75% done)**
 
 ### Pre-stable
@@ -198,6 +199,7 @@ Details:
 
 ### Changelog
 
+- 0.7.0 Addition of the option `enable_runtime_checks`. When false, all runtime checks in the given module are completely disabled.
 - 0.6.0 Addition of `spectest` & 'default overrides' Elixir's standard library types:
   - Adding `TypeCheck.ExUnit`, with the function `spectest` to test function-specifications.
     - Possibility to use options `:except`, `:only`, `:initial_seed`.

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -177,6 +177,7 @@ defmodule TypeCheck.Macros do
   defmacro __before_compile__(env) do
     defs = Module.get_attribute(env.module, TypeCheck.TypeDefs)
     typedef_names = Module.get_attribute(env.module, TypeCheck.TypeDefNames)
+    options = Module.get_attribute(env.module, TypeCheck.Options)
 
     compile_time_imports_module_name = Module.concat(TypeCheck.Internals.UserTypes, env.module)
 
@@ -197,7 +198,12 @@ defmodule TypeCheck.Macros do
     definitions = Module.definitions_in(env.module)
     specs = Module.get_attribute(env.module, TypeCheck.Specs)
     spec_defs = create_spec_defs(specs, definitions, env)
-    spec_quotes = wrap_functions_with_specs(specs, definitions, env)
+    spec_quotes =
+      if options.enable_runtime_checks do
+        wrap_functions_with_specs(specs, definitions, env)
+      else
+        quote do end
+      end
 
     spec_names = specs |> Enum.map(fn {name, _, arity, _, _, _} -> {name, arity} end)
 

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -198,6 +198,7 @@ defmodule TypeCheck.Macros do
     definitions = Module.definitions_in(env.module)
     specs = Module.get_attribute(env.module, TypeCheck.Specs)
     spec_defs = create_spec_defs(specs, definitions, env)
+
     spec_quotes =
       if options.enable_runtime_checks do
         wrap_functions_with_specs(specs, definitions, env)

--- a/lib/type_check/options.ex
+++ b/lib/type_check/options.ex
@@ -57,7 +57,8 @@ defmodule TypeCheck.Options do
     @type! t :: %TypeCheck.Options{
       overrides: type_overrides(),
       default_overrides: boolean(),
-      debug: boolean()
+      enable_runtime_checks: boolean(),
+      debug: boolean(),
     }
   else
     @type remote_type() :: mfa | function
@@ -66,11 +67,12 @@ defmodule TypeCheck.Options do
     @type t :: %TypeCheck.Options{
       overrides: list(type_override()),
       default_overrides: boolean(),
-      debug: boolean()
+      enable_runtime_checks: boolean(),
+      debug: boolean(),
     }
   end
 
-  defstruct [overrides: [], default_overrides: true, debug: false]
+  defstruct [overrides: [], default_overrides: true, enable_runtime_checks: true, debug: false]
 
   def new() do
     %__MODULE__{overrides: default_overrides()}

--- a/lib/type_check/options.ex
+++ b/lib/type_check/options.ex
@@ -106,8 +106,9 @@ defmodule TypeCheck.Options do
     @spec! new(enum :: any()) :: t()
   end
   def new(enum) do
-    raw_overrides = enum[:overrides] || []
-    debug = enum[:debug] || false
+    raw_overrides = Keyword.get(enum, :overrides, [])
+    debug = Keyword.get(enum, :debug, false)
+    enable_runtime_checks = Keyword.get(enum, :enable_runtime_checks, true)
 
     overrides = check_overrides!(raw_overrides)
     overrides =
@@ -117,7 +118,11 @@ defmodule TypeCheck.Options do
         overrides
       end
 
-    %__MODULE__{overrides: overrides, debug: debug}
+    %__MODULE__{
+      overrides: overrides,
+      enable_runtime_checks: enable_runtime_checks,
+      debug: debug
+    }
   end
 
   if_recompiling? do

--- a/lib/type_check/options.ex
+++ b/lib/type_check/options.ex
@@ -7,7 +7,8 @@ defmodule TypeCheck.Options do
 
   - `:overrides`: A list of overrides for remote types. (default: `[]`)
   - `:default_overrides`: A boolean. If false, will not include any of the overrides of the types of Elixir's standard library (c.f. `TypeCheck.DefaultOverrides.default_overrides/0`). (default: `true`)
-  - `:debug`: When true, will (at compile-time) print the generated TypeCheck-checking code. (default: `false`)
+  - `:enable_runtime_checks`: When true, functions that contain a `@spec!` will be wrapped with a runtime check which will check the input to and result returned from the function. (Default: `true`).
+  - `:debug`: When true, will (at compile-time) print the generated TypeCheck-checking code. (Default: `false`)
 
   These options are usually specified as passed to `use TypeCheck`,
   although they may also be passed in direct calls to `TypeCheck.conforms/3` (and its variants).
@@ -34,6 +35,25 @@ defmodule TypeCheck.Options do
   use TypeCheck, overrides: [
     {&Ecto.Schema.t/0, &MyProject.TypeCheckOverrides.Ecto.Schema.t/0}
   ]
+
+
+  ### Enabling/Disabling runtime checks
+
+  By default, runtime checks are enabled.
+
+  In the case where the runtime checks turn out to be too slow (for instance, because of working with very large or deeply nested collections) in a particular module,
+  they can be turned off completely.
+
+  It is recommended to:
+
+  - Only turn them off after benchmarking has shown that this will make a significant difference.
+  - Only turn them off in e.g. the production environment, keeping them on in the development and test environments.
+
+  An example:
+
+  ```elixir
+  use TypeCheck, enable_runtime_checks: Mix.env() != :prod
+  ```
 
   ### Debugging
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule TypeCheck.MixProject do
   def project do
     [
       app: :type_check,
-      version: "0.6.0",
+      version: "0.7.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/type_check/options_test.exs
+++ b/test/type_check/options_test.exs
@@ -142,10 +142,11 @@ defmodule TypeCheck.OptionsTest do
       defmodule EnableRuntimeChecksExample2 do
         use TypeCheck, enable_runtime_checks: false
         @spec! broken(number()) :: String.t()
-        def broken(val) do
+        def broken(_val) do
           false
         end
       end
+
 
       assert false == EnableRuntimeChecksExample2.broken(42)
     end

--- a/test/type_check/options_test.exs
+++ b/test/type_check/options_test.exs
@@ -123,4 +123,31 @@ defmodule TypeCheck.OptionsTest do
       assert "TypeCheck.Macros @spec generated:\n----------------\n" <> _rest = output
     end
   end
+
+  describe "enable_runtime_checks: false" do
+    test "functions now accept malformed data" do
+      defmodule EnableRuntimeChecksExample do
+        use TypeCheck, enable_runtime_checks: false
+        @spec! foo(number()) :: String.t()
+        def foo(val) do
+          to_string(val)
+        end
+      end
+
+      not_a_number = "Hello"
+      assert "Hello" == EnableRuntimeChecksExample.foo(not_a_number)
+    end
+
+    test "functions now can return malformed data" do
+      defmodule EnableRuntimeChecksExample2 do
+        use TypeCheck, enable_runtime_checks: false
+        @spec! broken(number()) :: String.t()
+        def broken(val) do
+          false
+        end
+      end
+
+      assert false == EnableRuntimeChecksExample2.broken(42)
+    end
+  end
 end


### PR DESCRIPTION
Addition of the option `enable_runtime_checks`. When false, all runtime checks in the given module are completely disabled.



Fixes #52 

