### PR TITLE
Brevity in pretty-printing named types, and colorized output

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Details:
 ### Changelog
 - master -
   - Fixes prettyprinting of `TypeCheck.Builtin.Range`.
+  - Addition of `require TypeCheck.Type` to `use TypeCheck` so there no longer is a need to call this manually if you want to e.g. use `TypeCheck.Type.build/1`.
 - 0.7.0 - Addition of the option `enable_runtime_checks`. When false, all runtime checks in the given module are completely disabled.
   - Adding `DateTime.t` to the default overrides, as it was still missing.
 - 0.6.0 - Addition of `spectest` & 'default overrides' Elixir's standard library types:

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -245,7 +245,7 @@ defmodule TypeCheck do
       {:ok, 42}
       iex> {:error, type_error} = TypeCheck.dynamic_conforms(20, fourty_two)
       iex> type_error.message
-      "At lib/type_check.ex:262:
+      "At lib/type_check.ex:264:
           `20` is not the same value as `42`."
   """
   @spec dynamic_conforms(value, TypeCheck.Type.t()) ::
@@ -297,7 +297,7 @@ defmodule TypeCheck do
       iex> TypeCheck.dynamic_conforms!(42, fourty_two)
       42
       iex> TypeCheck.dynamic_conforms!(20, fourty_two)
-      ** (TypeCheck.TypeError) At lib/type_check.ex:262:
+      ** (TypeCheck.TypeError) At lib/type_check.ex:264:
           `20` is not the same value as `42`.
   """
   @spec dynamic_conforms!(value, TypeCheck.Type.t()) :: value | no_return()

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -117,6 +117,7 @@ defmodule TypeCheck do
       nil ->
         quote generated: true, location: :keep do
           require TypeCheck
+          require TypeCheck.Type
           import TypeCheck.Builtin
           :ok
         end
@@ -124,6 +125,7 @@ defmodule TypeCheck do
         quote generated: true, location: :keep do
           use TypeCheck.Macros, unquote(options)
           require TypeCheck
+          require TypeCheck.Type
           import TypeCheck.Builtin
           :ok
         end

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -90,9 +90,9 @@ defmodule TypeCheck do
       {10, 20}
       iex> TypeCheck.conforms!({20, 10}, sorted_pair)
       ** (TypeCheck.TypeError) `{20, 10}` does not check against `(sorted_pair :: {lower :: number(), higher :: number()} when lower <= higher)`. Reason:
-        type guard:
-          `lower <= higher` evaluated to false or nil.
-          bound values: %{higher: 10, lower: 20, sorted_pair: {20, 10}}
+            type guard:
+              `lower <= higher` evaluated to false or nil.
+              bound values: %{higher: 10, lower: 20, sorted_pair: {20, 10}}
 
   Named types are available in your guard even from the (both local and remote) types that you are using in your time, as long as those types are not defined as _opaque_ types.
 
@@ -243,7 +243,7 @@ defmodule TypeCheck do
       {:ok, 42}
       iex> {:error, type_error} = TypeCheck.dynamic_conforms(20, fourty_two)
       iex> type_error.message
-      "At lib/type_check.ex:260:
+      "At lib/type_check.ex:262:
       `20` is not the same value as `42`."
   """
   @spec dynamic_conforms(value, TypeCheck.Type.t()) ::
@@ -295,8 +295,8 @@ defmodule TypeCheck do
       iex> TypeCheck.dynamic_conforms!(42, fourty_two)
       42
       iex> TypeCheck.dynamic_conforms!(20, fourty_two)
-      ** (TypeCheck.TypeError) At lib/type_check.ex:260:
-      `20` is not the same value as `42`.
+      ** (TypeCheck.TypeError) At lib/type_check.ex:262:
+          `20` is not the same value as `42`.
   """
   @spec dynamic_conforms!(value, TypeCheck.Type.t()) :: value | no_return()
   def dynamic_conforms!(value, type, options \\ TypeCheck.Options.new()) do

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -89,10 +89,12 @@ defmodule TypeCheck do
       iex> TypeCheck.conforms!({10, 20}, sorted_pair)
       {10, 20}
       iex> TypeCheck.conforms!({20, 10}, sorted_pair)
-      ** (TypeCheck.TypeError) `{20, 10}` does not check against `(sorted_pair :: {lower :: number(), higher :: number()} when lower <= higher)`. Reason:
-            type guard:
-              `lower <= higher` evaluated to false or nil.
-              bound values: %{higher: 10, lower: 20, sorted_pair: {20, 10}}
+      ** (TypeCheck.TypeError) `{20, 10}` does not match the definition of the named type `TypeCheckTest.TypeGuardExample.sorted_pair`
+          which is: `TypeCheckTest.TypeGuardExample.sorted_pair :: (sorted_pair when lower <= higher)`. Reason:
+            `{20, 10}` does not check against `(sorted_pair when lower <= higher)`. Reason:
+              type guard:
+                `lower <= higher` evaluated to false or nil.
+                bound values: %{higher: 10, lower: 20, sorted_pair: {20, 10}}
 
   Named types are available in your guard even from the (both local and remote) types that you are using in your time, as long as those types are not defined as _opaque_ types.
 
@@ -244,7 +246,7 @@ defmodule TypeCheck do
       iex> {:error, type_error} = TypeCheck.dynamic_conforms(20, fourty_two)
       iex> type_error.message
       "At lib/type_check.ex:262:
-      `20` is not the same value as `42`."
+          `20` is not the same value as `42`."
   """
   @spec dynamic_conforms(value, TypeCheck.Type.t()) ::
           {:ok, value} | {:error, TypeCheck.TypeError.t()}

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -822,7 +822,7 @@ defmodule TypeCheck.Builtin do
   and is thus represented as `type` (without the name) instead.
   """
   if_recompiling? do
-    @spec! named_type(name :: atom(), type :: TypeCheck.Type.t()) :: TypeCheck.Builtin.NamedType.t()
+    # @spec! named_type(name :: atom() | String.t(), type :: TypeCheck.Type.t()) :: TypeCheck.Builtin.NamedType.t()
   end
   def named_type(name, type) do
     TypeCheck.Type.ensure_type!(type)

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -149,7 +149,7 @@ defmodule TypeCheck.Builtin do
       1
       iex> TypeCheck.conforms!(1000, arity())
       ** (TypeCheck.TypeError) `1000` does not check against `0..255`. Reason:
-        `1000` falls outside the range 0..255.
+            `1000` falls outside the range 0..255.
   """
   if_recompiling? do
     @spec! arity() :: TypeCheck.Builtin.Range.t()
@@ -213,7 +213,7 @@ defmodule TypeCheck.Builtin do
       255
       iex> TypeCheck.conforms!(256, byte())
       ** (TypeCheck.TypeError) `256` does not check against `0..255`. Reason:
-        `256` falls outside the range 0..255.
+            `256` falls outside the range 0..255.
   """
   if_recompiling? do
     @spec! byte() :: TypeCheck.Builtin.Range.t()
@@ -232,7 +232,7 @@ defmodule TypeCheck.Builtin do
       97
       iex> TypeCheck.conforms!(-1, char())
       ** (TypeCheck.TypeError) `-1` does not check against `0..1114111`. Reason:
-        `-1` falls outside the range 0..1114111.
+            `-1` falls outside the range 0..1114111.
   """
   if_recompiling? do
     @spec! char() :: TypeCheck.Builtin.Range.t()
@@ -251,7 +251,7 @@ defmodule TypeCheck.Builtin do
       'hello world'
       iex> TypeCheck.conforms!("hello world", charlist())
       ** (TypeCheck.TypeError) `"hello world"` does not check against `list(0..1114111)`. Reason:
-        `"hello world"` is not a list.
+            `"hello world"` is not a list.
   """
   if_recompiling? do
     @spec! charlist() :: TypeCheck.Builtin.List.t(TypeCheck.Builtin.Range.t())
@@ -410,12 +410,12 @@ defmodule TypeCheck.Builtin do
 
       iex> TypeCheck.conforms!(:foo, list(integer()))
       ** (TypeCheck.TypeError) `:foo` does not check against `list(integer())`. Reason:
-        `:foo` is not a list.
+            `:foo` is not a list.
 
       iex> TypeCheck.conforms!([1, 2, 3.3], list(integer()))
       ** (TypeCheck.TypeError) `[1, 2, 3.3]` does not check against `list(integer())`. Reason:
-        at index 2:
-          `3.3` is not an integer.
+            at index 2:
+              `3.3` is not an integer.
   """
   if_recompiling? do
     @spec! list(a :: TypeCheck.Type.t()) :: TypeCheck.Builtin.List.t(TypeCheck.Type.t())
@@ -438,9 +438,9 @@ defmodule TypeCheck.Builtin do
       iex> y = [a: 1, b: 2] ++ [3, 4]
       iex> TypeCheck.conforms!(y, keyword())
       ** (TypeCheck.TypeError) `[{:a, 1}, {:b, 2}, 3, 4]` does not check against `list({atom(), any()})`. Reason:
-        at index 2:
-          `3` does not check against `{atom(), any()}`. Reason:
-            `3` is not a tuple.
+            at index 2:
+              `3` does not check against `{atom(), any()}`. Reason:
+                `3` is not a tuple.
   """
   if_recompiling? do
     @spec! keyword() :: TypeCheck.Builtin.List.t(TypeCheck.Builtin.FixedTuple.t())

--- a/lib/type_check/builtin/any.ex
+++ b/lib/type_check/builtin/any.ex
@@ -14,8 +14,9 @@ defmodule TypeCheck.Builtin.Any do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "any()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/atom.ex
+++ b/lib/type_check/builtin/atom.ex
@@ -26,8 +26,9 @@ defmodule TypeCheck.Builtin.Atom do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "atom()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/binary.ex
+++ b/lib/type_check/builtin/binary.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.Binary do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "binary()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/bitstring.ex
+++ b/lib/type_check/builtin/bitstring.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.Bitstring do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "bitstring()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/boolean.ex
+++ b/lib/type_check/builtin/boolean.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.Boolean do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "boolean()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/fixed_list.ex
+++ b/lib/type_check/builtin/fixed_list.ex
@@ -85,6 +85,7 @@ defmodule TypeCheck.Builtin.FixedList do
         opts
         | inspect_fun: &TypeCheck.Protocols.Inspect.inspect/2
       })
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/float.ex
+++ b/lib/type_check/builtin/float.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.Float do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "float()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/function.ex
+++ b/lib/type_check/builtin/function.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.Function do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "function()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -104,6 +104,7 @@ defmodule TypeCheck.Builtin.Guarded do
       |> Inspect.Algebra.glue(Macro.to_string(s.guard))
       |> Inspect.Algebra.concat(")")
       |> Inspect.Algebra.group()
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/implements_protocol.ex
+++ b/lib/type_check/builtin/implements_protocol.ex
@@ -25,7 +25,7 @@ defmodule TypeCheck.Builtin.ImplementsProtocol do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(s, _opts) do
+    def inspect(s, opts) do
       "impl(#{inspect(s.protocol)})"
       |> Inspect.Algebra.color(:builtin_type, opts)
     end

--- a/lib/type_check/builtin/implements_protocol.ex
+++ b/lib/type_check/builtin/implements_protocol.ex
@@ -27,6 +27,7 @@ defmodule TypeCheck.Builtin.ImplementsProtocol do
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(s, _opts) do
       "impl(#{inspect(s.protocol)})"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
   if Code.ensure_loaded?(StreamData) do

--- a/lib/type_check/builtin/integer.ex
+++ b/lib/type_check/builtin/integer.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.Integer do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "integer()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/lazy.ex
+++ b/lib/type_check/builtin/lazy.ex
@@ -38,6 +38,7 @@ defmodule TypeCheck.Builtin.Lazy do
       |> Inspect.Algebra.concat("#{inspect(s.module)}.#{s.function}(")
       |> Inspect.Algebra.concat(inspected_arguments)
       |> Inspect.Algebra.concat(")")
+      |> Inspect.Algebra.color(:builtin_type, opts)
 
       # "lazy( #{s.module}.#{s.function}(#{inspected_arguments}) )"
     end

--- a/lib/type_check/builtin/list.ex
+++ b/lib/type_check/builtin/list.ex
@@ -64,9 +64,9 @@ defmodule TypeCheck.Builtin.List do
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(list, opts) do
       Inspect.Algebra.container_doc(
-        "list(",
+        Inspect.Algebra.color("list(", :builtin_type, opts),
         [TypeCheck.Protocols.Inspect.inspect(list.element_type, opts)],
-        ")",
+        Inspect.Algebra.color(")", :builtin_type, opts),
         opts,
         fn x, _ -> x end,
         separator: "",

--- a/lib/type_check/builtin/list.ex
+++ b/lib/type_check/builtin/list.ex
@@ -72,6 +72,7 @@ defmodule TypeCheck.Builtin.List do
         separator: "",
         break: :maybe
       )
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/literal.ex
+++ b/lib/type_check/builtin/literal.ex
@@ -30,6 +30,7 @@ defmodule TypeCheck.Builtin.Literal do
         _ ->
           Inspect.Algebra.to_doc(literal.value, opts)
       end
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -85,8 +85,8 @@ defmodule TypeCheck.Builtin.Map do
         separator: ",",
         break: :maybe
       )
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
-    |> Inspect.Algebra.color(:builtin_type, opts)
   end
 
   if Code.ensure_loaded?(StreamData) do

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -86,6 +86,7 @@ defmodule TypeCheck.Builtin.Map do
         break: :maybe
       )
     end
+    |> Inspect.Algebra.color(:builtin_type, opts)
   end
 
   if Code.ensure_loaded?(StreamData) do

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -8,8 +8,8 @@ defmodule TypeCheck.Builtin.NamedType do
          {t(), :named_type, %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())},
           any()}
 
-  def stringify_name(atom, _) when is_atom(atom), do: to_string(atom)
-  def stringify_name(str, _) when is_binary(str), do: to_string(str)
+  def stringify_name(atom, _opts) when is_atom(atom), do: to_string(atom)
+  def stringify_name(str, _opts) when is_binary(str), do: to_string(str)
   def stringify_name(other, opts), do: TypeCheck.Protocols.Inspect.inspect(other, opts)
 
   defimpl TypeCheck.Protocols.ToCheck do

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -41,6 +41,7 @@ defmodule TypeCheck.Builtin.NamedType do
       else
         @for.stringify_name(literal.name, opts)
       end
+      |> Inspect.Algebra.color(:named_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -29,10 +29,14 @@ defmodule TypeCheck.Builtin.NamedType do
 
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(literal, opts) do
-      stringify_name(literal.name, opts)
-      |> Inspect.Algebra.glue("::")
-      |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(literal.type, opts))
-      |> Inspect.Algebra.group()
+      if Map.get(opts, :hide_long_named_type, false) do
+        stringify_name(literal.name, opts)
+      else
+        stringify_name(literal.name, opts)
+        |> Inspect.Algebra.glue("::")
+        |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(literal.type, opts))
+        |> Inspect.Algebra.group()
+      end
     end
     defp stringify_name(atom, _) when is_atom(atom), do: to_string(atom)
     defp stringify_name(str, _) when is_binary(str), do: to_string(str)

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -36,10 +36,10 @@ defmodule TypeCheck.Builtin.NamedType do
       if Map.get(opts, :show_long_named_type, false) do
         @for.stringify_name(literal.name, opts)
         |> Inspect.Algebra.glue("::")
-        |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(literal.type, opts))
+        |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(literal.type, Map.put(opts, :show_long_named_type, false)))
         |> Inspect.Algebra.group()
       else
-        @for.stringify_name(literal.name, opts) <> " :: _"
+        @for.stringify_name(literal.name, opts)
       end
     end
   end

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -8,6 +8,10 @@ defmodule TypeCheck.Builtin.NamedType do
          {t(), :named_type, %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())},
           any()}
 
+  def stringify_name(atom, _) when is_atom(atom), do: to_string(atom)
+  def stringify_name(str, _) when is_binary(str), do: to_string(str)
+  def stringify_name(other, opts), do: TypeCheck.Protocols.Inspect.inspect(other, opts)
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
       inner_check = TypeCheck.Protocols.ToCheck.to_check(s.type, param)
@@ -29,19 +33,17 @@ defmodule TypeCheck.Builtin.NamedType do
 
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(literal, opts) do
-      if Map.get(opts, :hide_long_named_type, false) do
-        stringify_name(literal.name, opts)
-      else
-        stringify_name(literal.name, opts)
+      if Map.get(opts, :show_long_named_type, false) do
+        @for.stringify_name(literal.name, opts)
         |> Inspect.Algebra.glue("::")
         |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(literal.type, opts))
         |> Inspect.Algebra.group()
+      else
+        @for.stringify_name(literal.name, opts) <> " :: _"
       end
     end
-    defp stringify_name(atom, _) when is_atom(atom), do: to_string(atom)
-    defp stringify_name(str, _) when is_binary(str), do: to_string(str)
-    defp stringify_name(other, opts), do: TypeCheck.Protocols.Inspect.inspect(other, opts)
   end
+
 
 
   if Code.ensure_loaded?(StreamData) do

--- a/lib/type_check/builtin/neg_integer.ex
+++ b/lib/type_check/builtin/neg_integer.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.NegInteger do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "neg_integer()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/non_neg_integer.ex
+++ b/lib/type_check/builtin/non_neg_integer.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.NonNegInteger do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "non_neg_integer()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/none.ex
+++ b/lib/type_check/builtin/none.ex
@@ -26,8 +26,9 @@ defmodule TypeCheck.Builtin.None do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "none()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/number.ex
+++ b/lib/type_check/builtin/number.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.Number do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "number()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -46,6 +46,7 @@ defmodule TypeCheck.Builtin.OneOf do
         separator: " |",
         break: :maybe
       )
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -55,7 +55,10 @@ defmodule TypeCheck.Builtin.OneOf do
       def to_gen(s) do
         choice_gens =
           s.choices
-          |> Enum.reject(fn choice -> match?(%TypeCheck.Builtin.None{}, choice) end)
+          |> Enum.reject(fn choice ->
+          match?(%TypeCheck.Builtin.None{}, choice)
+          || match?(%TypeCheck.Builtin.NamedType{type: %TypeCheck.Builtin.None{}}, choice)
+        end)
           |> Enum.map(&TypeCheck.Protocols.ToStreamData.to_gen/1)
 
         case choice_gens do

--- a/lib/type_check/builtin/pid.ex
+++ b/lib/type_check/builtin/pid.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.PID do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "pid()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/pos_integer.ex
+++ b/lib/type_check/builtin/pos_integer.ex
@@ -20,8 +20,9 @@ defmodule TypeCheck.Builtin.PosInteger do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "positive_integer()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/range.ex
+++ b/lib/type_check/builtin/range.ex
@@ -2,7 +2,12 @@ defmodule TypeCheck.Builtin.Range do
   defstruct [:range]
 
   use TypeCheck
-  @type! t :: %__MODULE__{range: %Range{first: integer(), last: integer(), step: 1}}
+
+  if Version.compare(System.version(), "1.12.0") == :lt do
+    @type! t :: %__MODULE__{range: %Range{first: integer(), last: integer()}}
+  else
+    @type! t :: %__MODULE__{range: %Range{first: integer(), last: integer(), step: 1}}
+  end
 
   @type! problem_tuple ::
          {t(), :not_an_integer, %{}, any()}

--- a/lib/type_check/builtin/range.ex
+++ b/lib/type_check/builtin/range.ex
@@ -2,7 +2,7 @@ defmodule TypeCheck.Builtin.Range do
   defstruct [:range]
 
   use TypeCheck
-  @type! t :: %__MODULE__{range: %Range{}}
+  @type! t :: %__MODULE__{range: %Range{first: integer(), last: integer(), step: 1}}
 
   @type! problem_tuple ::
          {t(), :not_an_integer, %{}, any()}

--- a/lib/type_check/builtin/range.ex
+++ b/lib/type_check/builtin/range.ex
@@ -28,6 +28,7 @@ defmodule TypeCheck.Builtin.Range do
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(struct, opts) do
       Inspect.Range.inspect(struct.range, opts)
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/tuple.ex
+++ b/lib/type_check/builtin/tuple.ex
@@ -26,8 +26,9 @@ defmodule TypeCheck.Builtin.Tuple do
   end
 
   defimpl TypeCheck.Protocols.Inspect do
-    def inspect(_, _opts) do
+    def inspect(_, opts) do
       "tuple()"
+      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -572,8 +572,6 @@ defmodule TypeCheck.Macros do
             pretty_module_name
         end
 
-      IO.inspect({pretty_module_name, overridden_modules}, label: :pretty_module_name)
-
       pretty_type_name = "#{inspect(pretty_module_name)}.#{Macro.to_string(name_with_params)}"
 
     quote generated: true, location: :keep do

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -56,10 +56,10 @@ defmodule TypeCheck.Macros do
 
   ```
   iex> MetaExample.joe
-  #TypeCheck.Type< %{coolness_level: :high, name: :joe} >
+  #TypeCheck.Type< %{TypeCheck.MacrosTest.MetaExample.joe() :: coolness_level: :high, name: :joe} >
 
   iex> MetaExample.mike
-  #TypeCheck.Type< %{coolness_level: :high, name: :mike} >
+  #TypeCheck.Type< TypeCheck.MacrosTest.MetaExample.mike() :: %{coolness_level: :high, name: :mike} >
 
   ```
 
@@ -107,14 +107,14 @@ defmodule TypeCheck.Macros do
 
   iex> GreeterExample.hi(42)
   ** (TypeCheck.TypeError) At test/type_check/macros_test.exs:32:
-  The call to `hi/1` failed,
-  because parameter no. 1 does not adhere to the spec `binary()`.
-  Rather, its value is: `42`.
-  Details:
-    The call `hi(42)`
-    does not adhere to spec `hi(binary()) :: binary()`. Reason:
-      parameter no. 1:
-        `42` is not a binary.
+      The call to `hi/1` failed,
+      because parameter no. 1 does not adhere to the spec `binary()`.
+      Rather, its value is: `42`.
+      Details:
+        The call `hi(42)`
+        does not adhere to spec `hi(binary()) :: binary()`. Reason:
+          parameter no. 1:
+            `42` is not a binary.
 
   ```
 

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -56,7 +56,7 @@ defmodule TypeCheck.Macros do
 
   ```
   iex> MetaExample.joe
-  #TypeCheck.Type< %{TypeCheck.MacrosTest.MetaExample.joe() :: coolness_level: :high, name: :joe} >
+  #TypeCheck.Type< TypeCheck.MacrosTest.MetaExample.joe() :: %{coolness_level: :high, name: :joe} >
 
   iex> MetaExample.mike
   #TypeCheck.Type< TypeCheck.MacrosTest.MetaExample.mike() :: %{coolness_level: :high, name: :mike} >

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -496,7 +496,7 @@ defmodule TypeCheck.Macros do
         {name, _, params} when is_list(params) -> {name, length(params)}
       end
 
-    res = type_fun_definition(name_with_maybe_params, type)
+    res = type_fun_definition(name_with_maybe_params, type, caller.module, typecheck_options.overrides)
 
     quote generated: true, location: :keep do
       if Module.get_attribute(__MODULE__, :autogen_typespec) do
@@ -550,7 +550,7 @@ defmodule TypeCheck.Macros do
     end
   end
 
-  defp type_fun_definition(name_with_params, type) do
+  defp type_fun_definition(name_with_params, type, module_name, overrides) do
     {_name, params} = Macro.decompose_call(name_with_params)
 
     params_check_code =
@@ -561,13 +561,28 @@ defmodule TypeCheck.Macros do
         end
       end)
 
+      overridden_modules = overrides |> Enum.map(fn {{m1, _f1, _a1}, {m2, _f2, _a2}} -> {m2, m1} end)
+
+      pretty_module_name = Keyword.get(overridden_modules, module_name, module_name)
+      pretty_module_name =
+        case Module.split(pretty_module_name) do
+          ["TypeCheck", "DefaultOverrides" | rest] ->
+            Module.concat(rest)
+          _ ->
+            pretty_module_name
+        end
+
+      IO.inspect({pretty_module_name, overridden_modules}, label: :pretty_module_name)
+
+      pretty_type_name = "#{inspect(pretty_module_name)}.#{Macro.to_string(name_with_params)}"
+
     quote generated: true, location: :keep do
       @doc false
       def unquote(name_with_params) do
         unquote_splicing(params_check_code)
         # import TypeCheck.Builtin
         unquote(type_expansion_loop_prevention_code(name_with_params))
-        unquote(type)
+        TypeCheck.Builtin.named_type(unquote(pretty_type_name), unquote(type))
       end
     end
   end

--- a/lib/type_check/protocols/inspect.ex
+++ b/lib/type_check/protocols/inspect.ex
@@ -85,7 +85,8 @@ defmodule TypeCheck.Inspect do
   def inspect(type, opts \\ %Inspect.Opts{})
   def inspect(type, opts) when is_list(opts) do
     opts =
-      Enum.reduce(opts, struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
+      opts ++ [syntax_colors: default_colors()]
+      Enum.reduce(struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
     inspect(type, opts)
   end
 
@@ -98,14 +99,32 @@ defmodule TypeCheck.Inspect do
   def inspect_binary(type, opts \\ %Inspect.Opts{})
   def inspect_binary(type, opts) when is_list(opts) do
     opts =
-      Enum.reduce(opts, struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
-    # opts = struct(Inspect.Opts, opts)
-    # struct(Inspect.Opts)
+      opts ++ [syntax_colors: default_colors() ++ [reset: opts[:reset_color] || :default_color]]
+      |> Enum.reduce(struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
     inspect_binary(type, opts)
   end
 
   def inspect_binary(type, opts = %Inspect.Opts{}) do
     TypeCheck.Inspect.inspect(type, opts)
     |> IO.iodata_to_binary()
+  end
+
+  @doc false
+  def default_colors() do
+    [
+      atom: :cyan,
+      string: :yellow,
+      list: :white,
+      boolean: :magenta,
+      nil: :light_magenta,
+      tuple: :white,
+      binary: :green,
+      map: :white,
+      number: :yellow,
+      range: :yellow,
+      default: :white,
+      named_type: :white,
+      builtin_type: :white
+    ]
   end
 end

--- a/lib/type_check/protocols/inspect.ex
+++ b/lib/type_check/protocols/inspect.ex
@@ -78,13 +78,27 @@ end
 
 defmodule TypeCheck.Inspect do
   @moduledoc false
-  def inspect(type, opts \\ %Inspect.Opts{}) do
+  import Kernel, except: [inspect: 2]
+
+  def inspect(type, opts \\ %Inspect.Opts{})
+  def inspect(type, opts) when is_list(opts) do
+    opts = struct(Inspect.Opts, opts)
+    inspect(type, opts)
+  end
+
+  def inspect(type, opts = %Inspect.Opts{}) do
     type
     |> TypeCheck.Protocols.Inspect.inspect(opts)
     |> Inspect.Algebra.format(opts.width)
   end
 
-  def inspect_binary(type, opts \\ %Inspect.Opts{}) do
+  def inspect_binary(type, opts \\ %Inspect.Opts{})
+  def inspect_binary(type, opts) when is_list(opts) do
+    opts = struct(Inspect.Opts, opts)
+    inspect_binary(type, opts)
+  end
+
+  def inspect_binary(type, opts = %Inspect.Opts{}) do
     TypeCheck.Inspect.inspect(type, opts)
     |> IO.iodata_to_binary()
   end

--- a/lib/type_check/protocols/inspect.ex
+++ b/lib/type_check/protocols/inspect.ex
@@ -85,8 +85,12 @@ defmodule TypeCheck.Inspect do
   def inspect(type, opts \\ %Inspect.Opts{})
   def inspect(type, opts) when is_list(opts) do
     opts =
-      opts ++ [syntax_colors: default_colors()]
-      Enum.reduce(struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
+      if IO.ANSI.enabled? do
+        opts ++ [syntax_colors: default_colors()]
+      else
+        opts
+      end
+      |> Enum.reduce(struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
     inspect(type, opts)
   end
 
@@ -99,7 +103,11 @@ defmodule TypeCheck.Inspect do
   def inspect_binary(type, opts \\ %Inspect.Opts{})
   def inspect_binary(type, opts) when is_list(opts) do
     opts =
-      opts ++ [syntax_colors: default_colors() ++ [reset: opts[:reset_color] || :default_color]]
+      if IO.ANSI.enabled? do
+        opts ++ [syntax_colors: default_colors() ++ [reset: opts[:reset_color] || :default_color]]
+      else
+        opts
+      end
       |> Enum.reduce(struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
     inspect_binary(type, opts)
   end

--- a/lib/type_check/protocols/inspect.ex
+++ b/lib/type_check/protocols/inspect.ex
@@ -39,6 +39,8 @@ structs = [
 for struct <- structs do
   defimpl Inspect, for: struct do
     def inspect(val, opts) do
+        opts = Map.put(opts, :show_long_named_type, true)
+
       "#TypeCheck.Type<"
       |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(val, opts))
       |> Inspect.Algebra.glue(">")
@@ -82,7 +84,8 @@ defmodule TypeCheck.Inspect do
 
   def inspect(type, opts \\ %Inspect.Opts{})
   def inspect(type, opts) when is_list(opts) do
-    opts = struct(Inspect.Opts, opts)
+    opts =
+      Enum.reduce(opts, struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
     inspect(type, opts)
   end
 
@@ -94,7 +97,10 @@ defmodule TypeCheck.Inspect do
 
   def inspect_binary(type, opts \\ %Inspect.Opts{})
   def inspect_binary(type, opts) when is_list(opts) do
-    opts = struct(Inspect.Opts, opts)
+    opts =
+      Enum.reduce(opts, struct(Inspect.Opts), fn {k, v}, res -> Map.put(res, k, v) end)
+    # opts = struct(Inspect.Opts, opts)
+    # struct(Inspect.Opts)
     inspect_binary(type, opts)
   end
 

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -211,20 +211,23 @@ defmodule TypeCheck.Spec do
     def inspect(struct, opts) do
       body =
         Inspect.Algebra.container_doc(
-          "(",
+          Inspect.Algebra.color("(", :named_type, opts),
           struct.param_types,
-          ")",
+          Inspect.Algebra.color(")", :named_type, opts),
           opts,
           &TypeCheck.Protocols.Inspect.inspect/2,
           separator: ", ",
           break: :maybe
         )
         |> Inspect.Algebra.group()
+        |> Inspect.Algebra.color(:named_type, opts)
 
       to_string(struct.name)
+      |> Inspect.Algebra.color(:named_type, opts)
       |> Inspect.Algebra.concat(body)
-      |> Inspect.Algebra.glue("::")
+      |> Inspect.Algebra.glue(Inspect.Algebra.color("::", :named_type, opts))
       |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(struct.return_type, opts))
+      |> Inspect.Algebra.color(:named_type, opts)
       |> Inspect.Algebra.group()
       |> Inspect.Algebra.color(:named_type, opts)
     end
@@ -236,6 +239,7 @@ defmodule TypeCheck.Spec do
       |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(struct, opts))
       |> Inspect.Algebra.glue(">")
       |> Inspect.Algebra.group()
+      |> Inspect.Algebra.color(:named_type, opts)
     end
   end
 

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -226,6 +226,7 @@ defmodule TypeCheck.Spec do
       |> Inspect.Algebra.glue("::")
       |> Inspect.Algebra.glue(TypeCheck.Protocols.Inspect.inspect(struct.return_type, opts))
       |> Inspect.Algebra.group()
+      |> Inspect.Algebra.color(:named_type, opts)
     end
   end
 

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -30,7 +30,7 @@ defmodule TypeCheck.Spec do
       ...(6)>
       ...(7)> {:ok, spec} = TypeCheck.Spec.lookup(Example, :greeter, 1)
       ...(8)> spec
-      #TypeCheck.Spec<  greeter(name :: binary()) :: binary() >
+      #TypeCheck.Spec<  greeter(name) :: binary() >
 
       iex> TypeCheck.Spec.lookup(Example, :nonexistent, 0)
       {:error, :not_found}
@@ -60,7 +60,7 @@ defmodule TypeCheck.Spec do
       ...(5)> end
       ...(6)>
       ...(7)> TypeCheck.Spec.lookup!(Example2, :greeter, 1)
-      #TypeCheck.Spec<  greeter(name :: binary()) :: binary() >
+      #TypeCheck.Spec<  greeter(name) :: binary() >
 
       iex> TypeCheck.Spec.lookup!(Example2, :nonexistent, 0)
       ** (ArgumentError) No spec found for `Example2.nonexistent/0`

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -250,7 +250,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   def do_format(
         {s = %TypeCheck.Spec{}, :return_error, %{problem: problem, arguments: arguments}, val}
       ) do
-    function_with_arity = IO.ANSI.format([:white, "#{s.name}/#{Enum.count(arguments)}", :red])
+    function_with_arity = IO.ANSI.format_fragment([:white, "#{s.name}/#{Enum.count(arguments)}", :red])
     result_spec = s.return_type |> TypeCheck.Inspect.inspect_binary(inspect_type_opts())
     arguments_str = arguments |> Enum.map(fn val -> inspect(val, inspect_type_opts()) end) |> Enum.join(", ")
     call = IO.ANSI.format_fragment([:white, "#{s.name}(#{arguments_str})", :red])

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -147,7 +147,15 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({s = %TypeCheck.Builtin.NamedType{}, :named_type, %{problem: problem}, val}) do
-    compound_check(val, s, do_format(problem))
+    child_str =
+      indent(do_format(problem))
+
+    """
+    `#{inspect(val)}` does not check against `#{TypeCheck.Inspect.inspect_binary(s, show_long_named_type: true)}`. Reason:
+    #{child_str}
+    """
+
+    # compound_check(val, s, do_format(problem))
   end
 
   def do_format({%TypeCheck.Builtin.None{}, :no_match, _, val}) do
@@ -262,7 +270,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       end
 
     """
-    `#{inspect(val)}` does not check against `#{TypeCheck.Inspect.inspect_binary(s)}`. Reason:
+    `#{inspect(val)}` does not check against `#{TypeCheck.Inspect.inspect_binary(s, hide_long_named_type: true)}`. Reason:
     #{child_str}
     """
   end

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -6,9 +6,9 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       do_format(problem_tuple)
       |> indent() # Ensure we start with four spaces, which multi-line exception pretty-printing expects
       |> indent()
-      |> String.trim()
 
     location_string(location) <> res
+    |> String.trim()
   end
 
   defp location_string([]), do: ""

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -6,7 +6,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       do_format(problem_tuple)
       |> indent() # Ensure we start with four spaces, which multi-line exception pretty-printing expects
       |> indent()
-      |> String.trim_trailing()
+      |> String.trim()
 
     location_string(location) <> res
   end
@@ -289,10 +289,18 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
 
   defp inspect_value_opts() do
     # [reset_color: :red, syntax_colors: ([reset: :white] ++ TypeCheck.Inspect.default_colors())]
-    [reset_color: :red, syntax_colors: ([reset: :red] ++ TypeCheck.Inspect.default_colors())]
+    if IO.ANSI.enabled? do
+      [reset_color: :red, syntax_colors: ([reset: :red] ++ TypeCheck.Inspect.default_colors())]
+    else
+      []
+    end
   end
 
   defp inspect_type_opts() do
-    [reset_color: :red, syntax_colors: ([reset: :red] ++ TypeCheck.Inspect.default_colors())]
+    if IO.ANSI.enabled? do
+      [reset_color: :red, syntax_colors: ([reset: :red] ++ TypeCheck.Inspect.default_colors())]
+    else
+      []
+    end
   end
 end

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -4,6 +4,8 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   def format(problem_tuple, location \\ []) do
     res =
       do_format(problem_tuple)
+      |> indent() # Ensure we start with four spaces, which multi-line exception pretty-printing expects
+      |> indent()
       |> String.trim_trailing()
 
     location_string(location) <> res

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -151,7 +151,8 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       indent(do_format(problem))
 
     """
-    `#{inspect(val)}` does not check against `#{TypeCheck.Inspect.inspect_binary(s, show_long_named_type: true)}`. Reason:
+    `#{inspect(val)}` does not match the definition of the named type `#{s.name}`
+    which is: `#{TypeCheck.Inspect.inspect_binary(s, show_long_named_type: true)}`. Reason:
     #{child_str}
     """
 
@@ -270,7 +271,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       end
 
     """
-    `#{inspect(val)}` does not check against `#{TypeCheck.Inspect.inspect_binary(s, hide_long_named_type: true)}`. Reason:
+    `#{inspect(val)}` does not check against `#{TypeCheck.Inspect.inspect_binary(s)}`. Reason:
     #{child_str}
     """
   end

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -29,23 +29,23 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   def do_format(problem_tuple)
 
   def do_format({%TypeCheck.Builtin.Atom{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not an atom."
+    "`#{inspect(val, inspect_value_opts())}` is not an atom."
   end
 
   def do_format({%TypeCheck.Builtin.Binary{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a binary."
+    "`#{inspect(val, inspect_value_opts())}` is not a binary."
   end
 
   def do_format({%TypeCheck.Builtin.Bitstring{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a bitstring."
+    "`#{inspect(val, inspect_value_opts())}` is not a bitstring."
   end
 
   def do_format({%TypeCheck.Builtin.Boolean{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a boolean."
+    "`#{inspect(val, inspect_value_opts())}` is not a boolean."
   end
 
   def do_format({s = %TypeCheck.Builtin.FixedList{}, :not_a_list, _, val}) do
-    problem = "`#{inspect(val)}` is not a list."
+    problem = "`#{inspect(val, inspect_value_opts())}` is not a list."
     compound_check(val, s, problem)
   end
 
@@ -53,7 +53,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
         {s = %TypeCheck.Builtin.FixedList{}, :different_length,
          %{expected_length: expected_length}, val}
       ) do
-    problem = "`#{inspect(val)}` has #{length(val)} elements rather than #{expected_length}."
+    problem = "`#{inspect(val, inspect_value_opts())}` has #{length(val)} elements rather than #{expected_length}."
     compound_check(val, s, problem)
   end
 
@@ -65,7 +65,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({s = %TypeCheck.Builtin.FixedMap{}, :not_a_map, _, val}) do
-    problem = "`#{inspect(val)}` is not a map."
+    problem = "`#{inspect(val, inspect_value_opts())}` is not a map."
     compound_check(val, s, problem)
   end
 
@@ -75,22 +75,22 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       |> Enum.map(&inspect/1)
       |> Enum.join(", ")
 
-    problem = "`#{inspect(val)}` is missing the following required key(s): `#{keys_str}`."
+    problem = "`#{inspect(val, inspect_value_opts())}` is missing the following required key(s): `#{keys_str}`."
     compound_check(val, s, problem)
   end
 
   def do_format(
         {s = %TypeCheck.Builtin.FixedMap{}, :value_error, %{problem: problem, key: key}, val}
       ) do
-    compound_check(val, s, "under key `#{inspect(key)}`:\n", do_format(problem))
+    compound_check(val, s, "under key `#{inspect(key, inspect_type_opts())}`:\n", do_format(problem))
   end
 
   def do_format({%TypeCheck.Builtin.Float{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a float."
+    "`#{inspect(val, inspect_value_opts())}` is not a float."
   end
 
   def do_format({%TypeCheck.Builtin.Function{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a function."
+    "`#{inspect(val, inspect_value_opts())}` is not a function."
   end
 
   def do_format({s = %TypeCheck.Builtin.Guarded{}, :type_failed, %{problem: problem}, val}) do
@@ -100,30 +100,30 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   def do_format({s = %TypeCheck.Builtin.Guarded{}, :guard_failed, %{bindings: bindings}, val}) do
     problem = """
     `#{Macro.to_string(s.guard)}` evaluated to false or nil.
-    bound values: #{inspect(bindings)}
+    bound values: #{inspect(bindings, inspect_type_opts())}
     """
 
     compound_check(val, s, "type guard:\n", problem)
   end
 
   def do_format({%TypeCheck.Builtin.Integer{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not an integer."
+    "`#{inspect(val, inspect_value_opts())}` is not an integer."
   end
 
   def do_format({%TypeCheck.Builtin.PosInteger{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a positive integer."
+    "`#{inspect(val, inspect_value_opts())}` is not a positive integer."
   end
 
   def do_format({%TypeCheck.Builtin.NegInteger{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a negative integer."
+    "`#{inspect(val, inspect_value_opts())}` is not a negative integer."
   end
 
   def do_format({%TypeCheck.Builtin.NonNegInteger{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a non-negative integer."
+    "`#{inspect(val, inspect_value_opts())}` is not a non-negative integer."
   end
 
   def do_format({s = %TypeCheck.Builtin.List{}, :not_a_list, _, val}) do
-    compound_check(val, s, "`#{inspect(val)}` is not a list.")
+    compound_check(val, s, "`#{inspect(val, inspect_value_opts())}` is not a list.")
   end
 
   def do_format(
@@ -133,11 +133,11 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({%TypeCheck.Builtin.Literal{value: expected_value}, :not_same_value, %{}, val}) do
-    "`#{inspect(val)}` is not the same value as `#{inspect(expected_value)}`."
+    "`#{inspect(val, inspect_value_opts())}` is not the same value as `#{inspect(expected_value, inspect_type_opts())}`."
   end
 
   def do_format({s = %TypeCheck.Builtin.Map{}, :not_a_map, _, val}) do
-    compound_check(val, s, "`#{inspect(val)}` is not a map.")
+    compound_check(val, s, "`#{inspect(val, inspect_value_opts())}` is not a map.")
   end
 
   def do_format({s = %TypeCheck.Builtin.Map{}, :key_error, %{problem: problem}, val}) do
@@ -145,7 +145,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({s = %TypeCheck.Builtin.Map{}, :value_error, %{problem: problem, key: key}, val}) do
-    compound_check(val, s, "under key `#{inspect(key)}`:\n", do_format(problem))
+    compound_check(val, s, "under key `#{inspect(key, inspect_type_opts())}`:\n", do_format(problem))
   end
 
   def do_format({s = %TypeCheck.Builtin.NamedType{}, :named_type, %{problem: problem}, val}) do
@@ -153,8 +153,8 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       indent(do_format(problem))
 
     """
-    `#{inspect(val)}` does not match the definition of the named type `#{s.name}`
-    which is: `#{TypeCheck.Inspect.inspect_binary(s, show_long_named_type: true)}`. Reason:
+    `#{inspect(val, inspect_value_opts())}` does not match the definition of the named type `#{Inspect.Algebra.format(Inspect.Algebra.color(to_string(s.name), :named_type, struct(Inspect.Opts, inspect_type_opts())), 80)}`
+    which is: `#{TypeCheck.Inspect.inspect_binary(s, [show_long_named_type: true] ++ inspect_type_opts())}`. Reason:
     #{child_str}
     """
 
@@ -162,11 +162,11 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({%TypeCheck.Builtin.None{}, :no_match, _, val}) do
-    "`#{inspect(val)}` does not match `none()` (no value matches `none()`)."
+    "`#{inspect(val, inspect_value_opts())}` does not match `none()` (no value matches `none()`)."
   end
 
   def do_format({%TypeCheck.Builtin.Number{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a number."
+    "`#{inspect(val, inspect_value_opts())}` is not a number."
   end
 
   def do_format({s = %TypeCheck.Builtin.OneOf{}, :all_failed, %{problems: problems}, val}) do
@@ -185,19 +185,19 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({%TypeCheck.Builtin.PID{}, :no_match, _, val}) do
-    "`#{inspect(val)}` is not a pid."
+    "`#{inspect(val, inspect_value_opts())}` is not a pid."
   end
 
   def do_format({s = %TypeCheck.Builtin.Range{}, :not_an_integer, _, val}) do
-    compound_check(val, s, "`#{inspect(val)}` is not an integer.")
+    compound_check(val, s, "`#{inspect(val, inspect_value_opts())}` is not an integer.")
   end
 
   def do_format({s = %TypeCheck.Builtin.Range{range: range}, :not_in_range, _, val}) do
-    compound_check(val, s, "`#{inspect(val)}` falls outside the range #{inspect(range)}.")
+    compound_check(val, s, "`#{inspect(val, inspect_value_opts())}` falls outside the range #{inspect(range, inspect_type_opts())}.")
   end
 
   def do_format({s = %TypeCheck.Builtin.FixedTuple{}, :not_a_tuple, _, val}) do
-    problem = "`#{inspect(val)}` is not a tuple."
+    problem = "`#{inspect(val, inspect_value_opts())}` is not a tuple."
     compound_check(val, s, problem)
   end
 
@@ -205,7 +205,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
         {s = %TypeCheck.Builtin.FixedTuple{}, :different_size, %{expected_size: expected_size},
          val}
       ) do
-    problem = "`#{inspect(val)}` has #{tuple_size(val)} elements rather than #{expected_size}."
+    problem = "`#{inspect(val, inspect_value_opts())}` has #{tuple_size(val)} elements rather than #{expected_size}."
     compound_check(val, s, problem)
   end
 
@@ -217,28 +217,28 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({s = %TypeCheck.Builtin.Tuple{}, :no_match, _, val}) do
-    problem = "`#{inspect(val)}` is not a tuple."
+    problem = "`#{inspect(val, inspect_value_opts())}` is not a tuple."
     compound_check(val, s, problem)
   end
 
   def do_format({%TypeCheck.Builtin.ImplementsProtocol{protocol: protocol_name}, :no_match, _, val}) do
-    "`#{inspect(val)}` does not implement the protocol `#{protocol_name}`"
+    "`#{inspect(val, inspect_value_opts())}` does not implement the protocol `#{protocol_name}`"
   end
 
   def do_format({s = %TypeCheck.Spec{}, :param_error, %{index: index, problem: problem}, val}) do
     # compound_check(val, s, "at parameter no. #{index + 1}:\n", do_format(problem))
     function_with_arity = "#{s.name}/#{Enum.count(val)}"
-    param_spec = s.param_types |> Enum.at(index) |> TypeCheck.Inspect.inspect_binary()
+    param_spec = s.param_types |> Enum.at(index) |> TypeCheck.Inspect.inspect_binary(inspect_type_opts())
     arguments = val |> Enum.map(&inspect/1) |> Enum.join(", ")
     call = "#{s.name}(#{arguments})"
 
     """
     The call to `#{function_with_arity}` failed,
     because parameter no. #{index + 1} does not adhere to the spec `#{param_spec}`.
-    Rather, its value is: `#{inspect(val |> Enum.at(index))}`.
+    Rather, its value is: `#{inspect(Enum.at(val, index), inspect_type_opts())}`.
     Details:
       The call `#{call}`
-      does not adhere to spec `#{TypeCheck.Inspect.inspect_binary(s)}`. Reason:
+      does not adhere to spec `#{TypeCheck.Inspect.inspect_binary(s, inspect_type_opts())}`. Reason:
         parameter no. #{index + 1}:
     #{indent(indent(indent(do_format(problem))))}
     """
@@ -248,17 +248,17 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
         {s = %TypeCheck.Spec{}, :return_error, %{problem: problem, arguments: arguments}, val}
       ) do
     function_with_arity = "#{s.name}/#{Enum.count(arguments)}"
-    result_spec = s.return_type |> TypeCheck.Inspect.inspect_binary()
+    result_spec = s.return_type |> TypeCheck.Inspect.inspect_binary(inspect_type_opts())
     arguments_str = arguments |> Enum.map(&inspect/1) |> Enum.join(", ")
     call = "#{s.name}(#{arguments_str})"
 
     """
     The call to `#{function_with_arity}` failed,
     because the returned result does not adhere to the spec `#{result_spec}`.
-    Rather, its value is: `#{inspect(val)}`.
+    Rather, its value is: `#{inspect(val, inspect_value_opts())}`.
     Details:
       The result of calling `#{call}`
-      does not adhere to spec `#{TypeCheck.Inspect.inspect_binary(s)}`. Reason:
+      does not adhere to spec `#{TypeCheck.Inspect.inspect_binary(s, inspect_type_opts())}`. Reason:
         Returned result:
     #{indent(indent(indent(do_format(problem))))}
     """
@@ -273,12 +273,21 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       end
 
     """
-    `#{inspect(val)}` does not check against `#{TypeCheck.Inspect.inspect_binary(s)}`. Reason:
+    `#{inspect(val, inspect_value_opts())}` does not check against `#{TypeCheck.Inspect.inspect_binary(s, inspect_type_opts())}`. Reason:
     #{child_str}
     """
   end
 
   defp indent(str) do
     String.replace("  " <> str, "\n", "\n  ")
+  end
+
+  defp inspect_value_opts() do
+    # [reset_color: :red, syntax_colors: ([reset: :white] ++ TypeCheck.Inspect.default_colors())]
+    [reset_color: :red, syntax_colors: ([reset: :red] ++ TypeCheck.Inspect.default_colors())]
+  end
+
+  defp inspect_type_opts() do
+    [reset_color: :red, syntax_colors: ([reset: :red] ++ TypeCheck.Inspect.default_colors())]
   end
 end

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -250,7 +250,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   def do_format(
         {s = %TypeCheck.Spec{}, :return_error, %{problem: problem, arguments: arguments}, val}
       ) do
-    function_with_arity = IO.ANSI.format([:white, "#{s.name}/#{Enum.count(arguments)}"])
+    function_with_arity = IO.ANSI.format([:white, "#{s.name}/#{Enum.count(arguments)}", :red])
     result_spec = s.return_type |> TypeCheck.Inspect.inspect_binary(inspect_type_opts())
     arguments_str = arguments |> Enum.map(fn val -> inspect(val, inspect_type_opts()) end) |> Enum.join(", ")
     call = IO.ANSI.format_fragment([:white, "#{s.name}(#{arguments_str})", :red])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
-ExUnit.start()
+Application.put_env(:elixir, :ansi_enabled, false)
+ExUnit.start(colors: [enabled: true])

--- a/test/type_check/builtin/any_test.exs
+++ b/test/type_check/builtin/any_test.exs
@@ -5,7 +5,8 @@ defmodule TypeCheck.Builtin.AnyTest do
 
   test "t() has the appropriate structure" do
     subject =  TypeCheck.Builtin.Any.t()
-    assert subject.__struct__ == TypeCheck.Builtin.FixedMap
-    assert subject.keypairs == [__struct__: literal(TypeCheck.Builtin.Any)]
+    assert subject.__struct__ == TypeCheck.Builtin.NamedType
+    assert subject.type.__struct__ == TypeCheck.Builtin.FixedMap
+    assert subject.type.keypairs == [__struct__: literal(TypeCheck.Builtin.Any)]
   end
 end

--- a/test/type_check/ex_unit_test.exs
+++ b/test/type_check/ex_unit_test.exs
@@ -33,14 +33,14 @@ defmodule TypeCheck.ExUnitTest do
       assert res =~ "Spectest failed (after 0 successful runs)"
       assert res =~ "Input: SpectestTestExample.mischievous_mannequin()"
       assert res =~ """
-           ** (TypeCheck.TypeError) The call to `mischievous_mannequin/0` failed,
-           because the returned result does not adhere to the spec `atom()`.
-           Rather, its value is: `42`.
-           Details:
-             The result of calling `mischievous_mannequin()`
-             does not adhere to spec `mischievous_mannequin() :: atom()`. Reason:
-               Returned result:
-                 `42` is not an atom.
+      ** (TypeCheck.TypeError) The call to `mischievous_mannequin/0` failed,
+               because the returned result does not adhere to the spec `atom()`.
+               Rather, its value is: `42`.
+               Details:
+                 The result of calling `mischievous_mannequin()`
+                 does not adhere to spec `mischievous_mannequin() :: atom()`. Reason:
+                   Returned result:
+                     `42` is not an atom.
       """
 
       # raptor failure is a MySpecialError:


### PR DESCRIPTION
- [x] Make named types shorter in many pretty-printing locations, as their definition is printed later on in a formatting tree anyway.
- [x] Colorize the output of the default formatter and the inspection protocol implementations.
- [x] Correctly turn _off_ colorization when disabled.
- [x] Make sure tests pass again (strongly related to prior point)