### PR TITLE
List literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Details:
   - Pretty-printing of types and TypeError output in multiple colors.
   - Nicer indentation of errors.
   - named types are now printed in abbreviated fashion if they are repeated multiple times in an error message. This makes a nested error message much easier to read, especially for larger specs.
+  - `[type]` no longer creates a `fixed_list(type)` but instead a `list(type)` (just as Elixir's own typespecs.)
+  - Support for `[...]` and `[type, ...]`as alias for `nonempty_list()` and `nonempty_list(type)` respectively.
+  - Remove support for list literals with multiple elements.
 - 0.7.0 - Addition of the option `enable_runtime_checks`. When false, all runtime checks in the given module are completely disabled.
   - Adding `DateTime.t` to the default overrides, as it was still missing.
 - 0.6.0 - Addition of `spectest` & 'default overrides' Elixir's standard library types:

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -756,7 +756,7 @@ defmodule TypeCheck.Builtin do
 
       tuple = %{__struct__: TypeCheck.Builtin.FixedTuple, element_types: element_types}
       when length(element_types) != 2 ->
-        raise "Improper type passed to `fixed_map/1` #{inspect(tuple)}"
+        raise TypeCheck.CompileError, "Improper type passed to `fixed_map/1` #{inspect(tuple)}"
 
       thing ->
         TypeCheck.Type.ensure_type!(thing)

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -39,7 +39,7 @@ defmodule TypeCheck.Builtin.Guarded do
           |> Enum.into(%MapSet{})
 
         if MapSet.size(names) > 1 do
-          raise """
+          raise TypeCheck.CompileError, """
           Attempted to construct a union type
           containing named types where one or multiple names
           do not exist in all of the possibilities:

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -98,13 +98,12 @@ defmodule TypeCheck.Builtin.Guarded do
 
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(s, opts) do
-      "("
+      ("(" |> Inspect.Algebra.color(:builtin_type, opts))
       |> Inspect.Algebra.concat(TypeCheck.Protocols.Inspect.inspect(s.type, opts))
-      |> Inspect.Algebra.glue("when")
-      |> Inspect.Algebra.glue(Macro.to_string(s.guard))
-      |> Inspect.Algebra.concat(")")
+      |> Inspect.Algebra.glue("when" |> Inspect.Algebra.color(:builtin_type, opts))
+      |> Inspect.Algebra.glue(Macro.to_string(s.guard) |> Inspect.Algebra.color(:builtin_type, opts))
+      |> Inspect.Algebra.concat(")"|> Inspect.Algebra.color(:builtin_type, opts))
       |> Inspect.Algebra.group()
-      |> Inspect.Algebra.color(:builtin_type, opts)
     end
   end
 

--- a/lib/type_check/builtin/implements_protocol.ex
+++ b/lib/type_check/builtin/implements_protocol.ex
@@ -35,7 +35,7 @@ defmodule TypeCheck.Builtin.ImplementsProtocol do
       def to_gen(s) do
         case s.protocol.__protocol__(:impls) do
           :not_consolidated ->
-            raise "values of the type #{inspect(s)} can only be generated when the protocol is consolidated."
+            raise TypeCheck.CompileError, "values of the type #{inspect(s)} can only be generated when the protocol is consolidated."
           {:consolidated, implementations} ->
             # Extract all implementations that have their own ToStreamData implementation.
             # raise "TODO #{inspect(implementations)}"

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -63,7 +63,7 @@ defmodule TypeCheck.Builtin.OneOf do
 
         case choice_gens do
           [] ->
-            raise "Cannot create a generator for `#{inspect(s)}` since it has no inhabiting values."
+            raise TypeCheck.CompileError, "Cannot create a generator for `#{inspect(s)}` since it has no inhabiting values."
 
           _ ->
             StreamData.one_of(choice_gens)

--- a/lib/type_check/compile_error.ex
+++ b/lib/type_check/compile_error.ex
@@ -1,0 +1,7 @@
+defmodule TypeCheck.CompileError do
+  @moduledoc """
+  Raised when during compilation of types or specifications,
+  an irrecoverable error occurs.
+  """
+  defexception [:message]
+end

--- a/lib/type_check/default_overrides/erlang/binary.ex
+++ b/lib/type_check/default_overrides/erlang/binary.ex
@@ -4,7 +4,7 @@ defmodule Elixir.TypeCheck.DefaultOverrides.Erlang.Binary do
   # TODO
   @opaque cp() :: {any(), reference()}
   @autogen_typespec false
-  @opaque! cp() :: {'am' | 'bm', term()}
+  @opaque! cp() :: {:am | :bm, term()}
 
   @opaque! part() :: {start :: non_neg_integer(), length :: integer()}
 end

--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -84,6 +84,15 @@ defmodule TypeCheck.Internals.PreExpander do
                quote generated: true, location: :keep do
                  TypeCheck.Builtin.nonempty_list(unquote(rewritten_element_type))
                end
+             other ->
+               raise """
+               TypeCheck does not support the list literal `#{Macro.to_string(other)}`
+               Currently supported are:
+               - [] -> empty list
+               - [type] -> list(type)
+               - [...] -> nonempty_list()
+               - [type, ...] -> nonempty_list(type)
+               """
            end
         # rewritten_values =
         #   list

--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -69,7 +69,7 @@ defmodule TypeCheck.Internals.PreExpander do
                quote generated: true, location: :keep do
                  TypeCheck.Builtin.literal(unquote([]))
                end
-             [{:..., _, Elixir}] ->
+             [{:..., _, _}] ->
                quote generated: true, location: :keep do
                  TypeCheck.Builtin.nonempty_list()
                end
@@ -79,7 +79,7 @@ defmodule TypeCheck.Internals.PreExpander do
                quote generated: true, location: :keep do
                  TypeCheck.Builtin.list(unquote(rewritten_element_type))
                end
-             [element_type, {:..., _, Elixir}] ->
+             [element_type, {:..., _, _}] ->
                rewritten_element_type = rewrite(element_type, env, options)
                quote generated: true, location: :keep do
                  TypeCheck.Builtin.nonempty_list(unquote(rewritten_element_type))

--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -85,7 +85,7 @@ defmodule TypeCheck.Internals.PreExpander do
                  TypeCheck.Builtin.nonempty_list(unquote(rewritten_element_type))
                end
              other ->
-               raise """
+               raise TypeCheck.CompileError, """
                TypeCheck does not support the list literal `#{Macro.to_string(other)}`
                Currently supported are:
                - [] -> empty list
@@ -119,7 +119,7 @@ defmodule TypeCheck.Internals.PreExpander do
         end
 
       ast = {:when, _, [_type, list]} when is_list(list) ->
-        raise ArgumentError, """
+        raise TypeCheck.CompileError, """
         Unsupported `when` with keyword arguments in the type description `#{Macro.to_string(ast)}`
 
         TypeCheck currently does not allow the `function(foo, bar) :: foo | bar when foo: some_type(), bar: other_type()` syntax.

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -243,7 +243,7 @@ defmodule TypeCheck.Macros do
   defp wrap_functions_with_specs(specs, definitions, caller) do
     for {name, location, arity, clean_params, params_ast, return_type_ast} <- specs do
       unless {name, arity} in definitions do
-        raise ArgumentError, "spec for undefined function #{name}/#{arity}"
+        raise TypeCheck.CompileError, "spec for undefined function #{name}/#{arity}"
       end
 
       require TypeCheck.Type

--- a/lib/type_check/options.ex
+++ b/lib/type_check/options.ex
@@ -143,7 +143,7 @@ defmodule TypeCheck.Options do
     {module_k, function_k, arity_k} = ensure_external_function!(original)
     {module_v, function_v, arity_v} = ensure_external_function!(override)
     if arity_k != arity_v do
-      raise "Error while parsing TypeCheck overides: override #{inspect(override)} does not have same arity as original type #{inspect(original)}."
+      raise TypeCheck.CompileError, "Error while parsing TypeCheck overides: override #{inspect(override)} does not have same arity as original type #{inspect(original)}."
     else
       {
         {module_k, function_k, arity_k},
@@ -152,7 +152,7 @@ defmodule TypeCheck.Options do
     end
   end
   defp check_override!(other) do
-    raise ArgumentError, "`check_overrides!` expects a list of two-element tuples `{mfa, mfa}` where `mfa` is either `{Module, function, arity}` or `&Module.function/arity`. However, an element not adhering to the `{mfa, mfa}` format was found: `#{inspect(other)}`."
+    raise TypeCheck.CompileError, "`check_overrides!` expects a list of two-element tuples `{mfa, mfa}` where `mfa` is either `{Module, function, arity}` or `&Module.function/arity`. However, an element not adhering to the `{mfa, mfa}` format was found: `#{inspect(other)}`."
   end
 
   defp ensure_external_function!(fun) when is_function(fun) do
@@ -161,13 +161,13 @@ defmodule TypeCheck.Options do
         info = Function.info(fun)
         {info[:module], info[:name], info[:arity]}
       _other ->
-        raise "Error while parsing TypeCheck overides: #{inspect(fun)} is not an external function of the format `&Module.function/arity`!"
+        raise TypeCheck.CompileError, "Error while parsing TypeCheck overides: #{inspect(fun)} is not an external function of the format `&Module.function/arity`!"
     end
   end
   defp ensure_external_function!({module, function, arity}) when is_atom(module) and is_atom(function) and arity >= 0 do
     {module, function, arity}
   end
   defp ensure_external_function!(fun) do
-    raise "Error while parsing TypeCheck overides: #{inspect(fun)} is not a function!"
+    raise TypeCheck.CompileError, "Error while parsing TypeCheck overides: #{inspect(fun)} is not a function!"
   end
 end

--- a/lib/type_check/type.ex
+++ b/lib/type_check/type.ex
@@ -105,7 +105,7 @@ defmodule TypeCheck.Type do
   def ensure_type!(possibly_a_type) do
     case TypeCheck.Protocols.ToCheck.impl_for(possibly_a_type) do
       nil ->
-        raise """
+        raise TypeCheck.CompileError, """
         Invalid value passed to a function expecting a type!
         `#{inspect(possibly_a_type)}` is not a valid TypeCheck type.
         You probably tried to use a TypeCheck type as a function directly.

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -98,8 +98,10 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format({s = %TypeCheck.Builtin.Guarded{}, :guard_failed, %{bindings: bindings}, val}) do
+    guard_str = Inspect.Algebra.format(Inspect.Algebra.color(Macro.to_string(s.guard), :builtin_type, struct(Inspect.Opts, inspect_type_opts())), 80)
+
     problem = """
-    `#{Macro.to_string(s.guard)}` evaluated to false or nil.
+    `#{guard_str}` evaluated to false or nil.
     bound values: #{inspect(bindings, inspect_type_opts())}
     """
 

--- a/test/type_check/builtin/implements_protocol_test.exs
+++ b/test/type_check/builtin/implements_protocol_test.exs
@@ -40,7 +40,7 @@ defmodule TypeCheck.Builtin.ImplementsProtocolTest do
         def foo(_impl)
       end
 
-      assert_raise(RuntimeError, "values of the type #TypeCheck.Type< impl(TypeCheck.Builtin.ImplementsProtocolTest.ThisProtocolIsNotConsolidated) > can only be generated when the protocol is consolidated.", fn ->
+      assert_raise(TypeCheck.CompileError, "values of the type #TypeCheck.Type< impl(TypeCheck.Builtin.ImplementsProtocolTest.ThisProtocolIsNotConsolidated) > can only be generated when the protocol is consolidated.", fn ->
         TypeCheck.Protocols.ToStreamData.to_gen(impl(ThisProtocolIsNotConsolidated))
       end)
     end

--- a/test/type_check/builtin_test.exs
+++ b/test/type_check/builtin_test.exs
@@ -29,7 +29,7 @@ defmodule TypeCheck.BuiltinTest do
         float()
       end => TypeCheck.Builtin.Float,
       quote do
-        [1, 2]
+        fixed_list([1, 2])
       end => TypeCheck.Builtin.FixedList,
       quote do
         %{a: 1, b: integer()}
@@ -53,7 +53,7 @@ defmodule TypeCheck.BuiltinTest do
         map(atom(), any())
       end => TypeCheck.Builtin.Map,
       quote do
-        list()
+        [integer()]
       end => TypeCheck.Builtin.List,
       quote do
         literal(42)

--- a/test/type_check/type_test.exs
+++ b/test/type_check/type_test.exs
@@ -17,6 +17,6 @@ defmodule TypeCheck.TypeTest do
   end
 
   test "ensure_type! raises on non-types with a descriptive message" do
-    assert_raise(RuntimeError, ~r{^Invalid value passed to a function expecting a type!}, fn -> TypeCheck.Type.ensure_type!(42) end)
+    assert_raise(TypeCheck.CompileError, ~r{^Invalid value passed to a function expecting a type!}, fn -> TypeCheck.Type.ensure_type!(42) end)
   end
 end


### PR DESCRIPTION
- [x] Better literal list recognition (c.f. #8 ):
  - `[]` is recognized as `literal([])`
  - `[type]` is recognized as `list(type)`
  - `[...]` is recognized as `nonempty_list(any())`
  - `[type, ...]` is recognized as `nonempty_list(type)`
  - `[more, types]` and [even, more, types]  trigger a compile-time error.
  - `fixed_list([more, types])` can be used to make fixed lists if really desired.
- [x] Properly color type guards in exceptions
- [x] Introduce `TypeCheck.CompileError` to be raised when a problem is encountered at compile time (such as a type-building macro being passed improper parameters). Until now, either `RuntimeError` was used for this.