### PR TITLE
Add Range.t() builtin

### DIFF
--- a/lib/type_check/default_overrides/range.ex
+++ b/lib/type_check/default_overrides/range.ex
@@ -3,9 +3,13 @@ defmodule TypeCheck.DefaultOverrides.Range do
   @type! limit() :: integer()
 
   if Version.compare(System.version(), "1.12.0") == :lt do
+    @type! t() :: %Elixir.Range{first: limit(), last: limit()}
+
     @type! t(first, last) :: %Elixir.Range{first: first, last: last}
   else
     @type! step() :: pos_integer() | neg_integer()
+
+    @type! t() :: %Elixir.Range{first: limit(), last: limit(), step: step()}
 
     @type! t(first, last) :: %Elixir.Range{first: first, last: last, step: step()}
   end


### PR DESCRIPTION
It appears `Range.t/0` was missing from the builtin and is added in this PR. Let me know if I've missed anything here.