### PR TITLE
Swap Murmur out for `:erlang.phash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Details:
 - [ ] Per-module or even per-spec settings to turn on/off, configure formatter, etc.
 
 ### Changelog
+- 0.10.1 - 
+  - Fixes:
+    - Swaps `Murmur` out for Erlang's builtin `:erlang.phash/2` to generate data for function-types, allowing the removal of the optional dependency on the `:murmur` library.
 - 0.10.0 -
   - Additions
     - Support for function-types (for typechecks as well as property-testing generators):
@@ -280,10 +283,8 @@ by adding `type_check` to your list of dependencies in `mix.exs`:
 def deps do
   [
     {:type_check, "~> 0.9.0"},
-    # Optional, to allow spectesting and property-testing data generators:
+    # To allow spectesting and property-testing data generators (optional):
     {:stream_data, "~> 0.5.0", only: :test}, 
-    # Optional, to allow spectesting/property-testing for higher-order function-types specifically:
-    {:murmur, "~> 1.0", only: :test},
   ]
 end
 ```

--- a/lib/type_check/builtin/function.ex
+++ b/lib/type_check/builtin/function.ex
@@ -163,7 +163,7 @@ defmodule TypeCheck.Builtin.Function do
     end
   end
 
-  if Code.ensure_loaded?(StreamData) && Code.ensure_loaded(Murmur) do
+  if Code.ensure_loaded?(StreamData) do
     defimpl TypeCheck.Protocols.ToStreamData do
       def to_gen(s) do
         case s do
@@ -187,10 +187,7 @@ defmodule TypeCheck.Builtin.Function do
         wrapper_ast =
           quote do
           fn unquote_splicing(clean_params) ->
-            persistent_seed =
-              unquote(clean_params)
-              |> :erlang.term_to_binary()
-              |> Murmur.hash_x86_32(unquote(hash_seed))
+            persistent_seed = :erlang.phash(unquote(clean_params), unquote(hash_seed))
 
             unquote(Macro.escape(result_type))
             |> TypeCheck.Protocols.ToStreamData.to_gen()

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule TypeCheck.MixProject do
   def project do
     [
       app: :type_check,
-      version: "0.10.0",
+      version: "0.10.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -65,8 +65,6 @@ defmodule TypeCheck.MixProject do
     [
       # Used for spectesting and property-tests in general:
       {:stream_data, "~> 0.5.0", optional: true},
-      # Used for spectesting and property-test generators for function-types:
-      {:murmur, "~> 1.0", optional: true},
 
       # For documentation purposes:
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},


### PR DESCRIPTION
Swaps `Murmur` out for Erlang's builtin `:erlang.phash/2` to generate data for function-types, allowing the removal of the optional dependency on the `:murmur` library.