### PR TITLE
Ensures calls to `def`/`defp`/`defmacro`/`defmacrop` are always qualified

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Details:
 - [ ] Per-module or even per-spec settings to turn on/off, configure formatter, etc.
 
 ### Changelog
+- 0.10.3 - 
+  - Fixes:
+    - Fixes issue when TypeCheck specs were used inside a defprotocol module or other modules where the normal `def`/`defp` macros are hidden/overridden.
 - 0.10.2 - 
   - Fixes:
     - Fixes issue where FixedMaps would accept maps any maps (even those missing the required keys) sometimes. (c.f. #74)

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -148,7 +148,7 @@ defmodule TypeCheck.Spec do
 
       defoverridable([{unquote(name), unquote(arity)}])
 
-      unquote(function_kind)(unquote(name)(unquote_splicing(clean_params)), do: unquote(body))
+      Kernel.unquote(function_kind)(unquote(name)(unquote_splicing(clean_params)), do: unquote(body))
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule TypeCheck.MixProject do
   def project do
     [
       app: :type_check,
-      version: "0.10.2",
+      version: "0.10.3",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
(i.e. prefixed with 'Kernel.'), so they will also work in `defprotocol`
modules or other places where the normal versions of these macros are
hidden/overridden.

Fixes a bug reported on the Elixir forums by user 'belteconti'.