### PR TITLE
Fix broken markdown in @moduledoc

### DIFF
--- a/lib/type_check/options.ex
+++ b/lib/type_check/options.ex
@@ -35,7 +35,7 @@ defmodule TypeCheck.Options do
   use TypeCheck, overrides: [
     {&Ecto.Schema.t/0, &MyProject.TypeCheckOverrides.Ecto.Schema.t/0}
   ]
-
+  ```
 
   ### Enabling/Disabling runtime checks
 
@@ -59,7 +59,6 @@ defmodule TypeCheck.Options do
 
   Passing the option `debug: true` will at compile-time print the generated code
   for all added `@spec`s, as well as `TypeCheck.conforms/3`/`TypeCheck.conforms?/3`/`TypeCheck.conforms!/3` calls.
-  ```
   """
 
   if_recompiling? do


### PR DESCRIPTION
The [hexdoc description page](https://hexdocs.pm/type_check/TypeCheck.Options.html) for `TypeCheck.Options` is a little bit broken.