### PR TITLE
Check there are no superfluous keys in a map

### DIFF
--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -5,6 +5,7 @@ defmodule TypeCheck.Builtin.FixedMap do
   On failure returns a problem tuple with:
   - `:not_a_map` if the value is not a map
   - `:missing_keys` if the value does not have all of the expected keys. The extra information contains in this case `:keys` with a list of keys that are missing.
+  - `:superfluous_keys` if the value have any keys other than the expected keys. The extra information contains in this case `:keys` with a list of keys that are superfluous.
   - `:value_error` if one of the elements does not match. The extra information contains in this case `:problem` and `:key` to indicate what and where the problem occured.
   """
   defstruct [:keypairs]

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -91,6 +91,19 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
       |> Enum.join(", ")
 
     problem = "`#{inspect(val, inspect_value_opts())}` is missing the following required key(s): `#{keys_str}`."
+
+    compound_check(val, s, problem)
+  end
+  
+  def do_format({s = %TypeCheck.Builtin.FixedMap{}, :superfluous_keys, %{keys: keys}, val}) do
+    keys_str =
+      keys
+      |> Enum.map(&inspect/1)
+      |> Enum.join(", ")
+
+    problem =
+      "`#{inspect(val, inspect_value_opts())}` contains the following superfluous key(s): `#{keys_str}`."
+
     compound_check(val, s, problem)
   end
 


### PR DESCRIPTION
I just spent a lot of time trying to understand an issue in my code. The issue turned out to be that I used the wrong name for a field in a map. I've looked at TypeCheck before, and thought I'd have a new look at it and see if it would have helped me.

[The docs for `fixed_map`](https://hexdocs.pm/type_check/TypeCheck.Builtin.html#fixed_map/1) says that "A map with exactly the key-value-pairs indicated by keywords", which made me think that was the case, so it would throw an error if I tried to call my function with the wrong parameter. 

However, this wasn't the case, and when I looked at the code I found the [comment](https://github.com/Qqwy/elixir-type_check/blob/master/lib/type_check/builtin/fixed_map.ex#L52) "# TODO raise on superfluous keys (just like Elixir's built-in typespecs do not allow them)".

Since it seems that this is the functionality that you want I tried to implement this, and came up with this PR. The code is heavily based on the already existing code for the presence of keys. 

I also added code to format the new problem tuple and tests for the new case and a simple test for a conforming map to make it harder to destroy existing functionality. 