### PR TITLE
Fix Inspect implementation for SizedBitstring

### DIFF
--- a/lib/type_check/builtin/sized_bitstring.ex
+++ b/lib/type_check/builtin/sized_bitstring.ex
@@ -42,11 +42,19 @@ defmodule TypeCheck.Builtin.SizedBitstring do
       unit_size = s.unit_size |> to_string() |> Inspect.Algebra.color(:number, opts)
       cond do
         s.unit_size == nil ->
-          "<<_::#{prefix_size}>>"
+          "<<_::"
+          |> Inspect.Algebra.concat(prefix_size)
+          |> Inspect.Algebra.concat(Inspect.Algebra.color(">>", :binary, opts))
         s.prefix_size == 0 ->
-          "<<_::_*#{unit_size}>>"
+          "<<_::_*"
+          |> Inspect.Algebra.concat(unit_size)
+          |> Inspect.Algebra.concat(Inspect.Algebra.color(">>", :binary, opts))
         true ->
-          "<<_::#{prefix_size}, _::_*#{unit_size}>>"
+          "<<_::"
+          |> Inspect.Algebra.concat(prefix_size)
+          |> Inspect.Algebra.concat(Inspect.Algebra.color(", _::_*", :binary, opts))
+          |> Inspect.Algebra.concat(unit_size)
+          |> Inspect.Algebra.concat(Inspect.Algebra.color(">>", :binary, opts))
       end
       |> Inspect.Algebra.color(:binary, opts)
     end

--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -138,7 +138,7 @@ defmodule TypeCheck.Internals.PreExpander do
                TypeCheck does not support the bitstring literal `#{Macro.to_string(bitstring)}`
                Currently supported are:
                - <<>> -> empty bitstring
-               - <<_ :: size >> -> a bitstring of exactly `size` bytes long
+               - <<_ :: size >> -> a bitstring of exactly `size` bits long
                - <<_ :: _ * unit >> -> a bitstring whose length is divisible by `unit`.
                - <<_ :: size, _ * unit >> -> a bitstring whose (length - `size`) is divisible by `unit`.
                """


### PR DESCRIPTION
This fixes an issue found with inspecting SizedBitstring structs, mentioned in #104 (unfortunately it does not seem to affect the part about `mix dialyzer` mentioned in that issue).

This is my first time using Inspect.Algebra - let me know if the code is horrible 😄 