### PR TITLE
Parser for regular Elixir @spec

### DIFF
--- a/lib/type_check/internals/parser.ex
+++ b/lib/type_check/internals/parser.ex
@@ -1,0 +1,87 @@
+defmodule TypeCheck.Internals.Parser do
+  @moduledoc false
+
+  alias TypeCheck.Builtin, as: B
+
+  @spec fetch_spec(atom() | list(), atom(), non_neg_integer()) ::
+          {:error, String.t()} | {:ok, tuple()}
+  def fetch_spec(module, function, arity) when is_atom(module) do
+    case Code.Typespec.fetch_specs(module) do
+      {:ok, specs} -> fetch_spec(specs, function, arity)
+      :error -> {:error, "cannot fetch specs from the module"}
+    end
+  end
+
+  def fetch_spec(specs, function, arity) when is_list(specs) do
+    case specs |> Enum.find(fn {func, _spec} -> func == {function, arity} end) do
+      {_func, [spec]} -> {:ok, spec}
+      {_func, _spec} -> {:error, "unsupported spec"}
+      nil -> {:error, "cannot find spec for function"}
+    end
+  end
+
+  # TODO: as_boolean, bounded_fun, fun(), mfa, half-open range, map(a, b),
+  # sized bitstring, none, no_return
+  @spec convert!(tuple()) :: TypeCheck.Type.t()
+
+  # basic types
+  def convert!({:type, _, :any, []}), do: B.any()
+  def convert!({:type, _, :atom, []}), do: B.atom()
+  def convert!({:type, _, :binary, []}), do: B.binary()
+  def convert!({:type, _, :bitstring, []}), do: B.bitstring()
+  def convert!({:type, _, :boolean, []}), do: B.boolean()
+  def convert!({:type, _, :integer, []}), do: B.integer()
+  def convert!({:type, _, :non_neg_integer, []}), do: B.non_neg_integer()
+  def convert!({:type, _, :pos_integer, []}), do: B.pos_integer()
+  def convert!({:type, _, :float, []}), do: B.float()
+  def convert!({:type, _, :number, []}), do: B.number()
+  def convert!({:type, _, :pid, []}), do: B.pid()
+
+  # literals
+  def convert!({:atom, _, val}), do: B.literal(val)
+  def convert!({:integer, _, val}), do: B.literal(val)
+
+  def convert!({:type, _, :range, [{:integer, _, left}, {:integer, _, right}]}),
+    do: B.range(left, right)
+
+  # aliases
+  def convert!({:type, _, :term, []}), do: B.term()
+  def convert!({:type, _, :arity, []}), do: B.arity()
+  def convert!({:type, _, :module, []}), do: B.module()
+  def convert!({:type, _, :nonempty_binary, []}), do: B.nonempty_binary()
+  def convert!({:type, _, :nonempty_bitstring, []}), do: B.nonempty_bitstring()
+  def convert!({:type, _, :byte, []}), do: B.byte()
+  def convert!({:type, _, :char, []}), do: B.char()
+  def convert!({:type, _, :charlist, []}), do: B.charlist()
+
+  # shothands for generics
+  def convert!({:type, _, :fun, [{:type, _, :any}, ret_type]}), do: B.function(convert!(ret_type))
+  def convert!({:type, _, :list, []}), do: B.list()
+  def convert!({:type, _, :nonempty_list, []}), do: B.nonempty_list()
+  def convert!({:type, _, :map, :any}), do: B.map()
+
+  # generics
+  def convert!({:type, _, :fun, [{:type, _, :product, arg_types}, ret_type]}),
+    do: B.function(Enum.map(arg_types, &convert!/1), convert!(ret_type))
+
+  def convert!({:type, _, :list, [t]}), do: B.list(convert!(t))
+
+  def convert!({:type, 0, :tuple, types}),
+    do: B.fixed_tuple(Enum.map(types, &convert!/1))
+
+  def convert!({:type, 0, :union, types}),
+    do: B.one_of(Enum.map(types, &convert!/1))
+
+  # remote types
+
+  def convert!({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :keyword}, []]}),
+    do: B.keyword()
+
+  def convert!({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :keyword}, [t]]}),
+    do: B.keyword(convert!(t))
+
+  def convert!({:remote_type, _, [{:atom, _, :String}, {:atom, _, :t}, []]}),
+    do: B.bitstring()
+
+  def convert!(_), do: raise("unsupported type")
+end

--- a/lib/type_check/internals/parser.ex
+++ b/lib/type_check/internals/parser.ex
@@ -34,6 +34,8 @@ defmodule TypeCheck.Internals.Parser do
   @doc """
   Convert the raw spec extracted by `fetch_spec/3` into type_check type.
 
+  The function is optimistic. If the type is not known, it assumes `any()`.
+
       iex> import TypeCheck.Builtin
       iex> import TypeCheck.Internals.Parser
       iex> {:ok, spec} = fetch_spec(Kernel, :is_atom, 1)
@@ -41,7 +43,6 @@ defmodule TypeCheck.Internals.Parser do
       iex> ^expected = convert(spec)
   """
   # TODO(@orsinium):
-  #  as_boolean
   #  map(a, b)
   #  mfa
   #  keyword(t)
@@ -126,6 +127,9 @@ defmodule TypeCheck.Internals.Parser do
 
   def convert({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :keyword}, [t]]}),
     do: B.keyword(convert(t))
+
+  def convert({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :as_boolean}, [t]]}),
+    do: B.as_boolean(convert(t))
 
   def convert({:remote_type, _, [{:atom, _, :String}, {:atom, _, :t}, []]}),
     do: B.bitstring()

--- a/lib/type_check/internals/parser.ex
+++ b/lib/type_check/internals/parser.ex
@@ -15,73 +15,81 @@ defmodule TypeCheck.Internals.Parser do
   def fetch_spec(specs, function, arity) when is_list(specs) do
     case specs |> Enum.find(fn {func, _spec} -> func == {function, arity} end) do
       {_func, [spec]} -> {:ok, spec}
+      {_func, [_ | _]} -> {:error, "multiple specs for function"}
       {_func, _spec} -> {:error, "unsupported spec"}
       nil -> {:error, "cannot find spec for function"}
     end
   end
 
-  # TODO: as_boolean, bounded_fun, fun(), mfa, half-open range, map(a, b),
+  # TODO(@orsinium): as_boolean, bounded_fun, fun(), mfa, half-open range, map(a, b),
   # sized bitstring, none, no_return
-  @spec convert!(tuple()) :: TypeCheck.Type.t()
+  @spec convert(tuple()) :: TypeCheck.Type.t()
 
   # basic types
-  def convert!({:type, _, :any, []}), do: B.any()
-  def convert!({:type, _, :atom, []}), do: B.atom()
-  def convert!({:type, _, :binary, []}), do: B.binary()
-  def convert!({:type, _, :bitstring, []}), do: B.bitstring()
-  def convert!({:type, _, :boolean, []}), do: B.boolean()
-  def convert!({:type, _, :integer, []}), do: B.integer()
-  def convert!({:type, _, :non_neg_integer, []}), do: B.non_neg_integer()
-  def convert!({:type, _, :pos_integer, []}), do: B.pos_integer()
-  def convert!({:type, _, :float, []}), do: B.float()
-  def convert!({:type, _, :number, []}), do: B.number()
-  def convert!({:type, _, :pid, []}), do: B.pid()
+  def convert({:type, _, :any, []}), do: B.any()
+  def convert({:type, _, :atom, []}), do: B.atom()
+  def convert({:type, _, :binary, []}), do: B.binary()
+  def convert({:type, _, :bitstring, []}), do: B.bitstring()
+  def convert({:type, _, :boolean, []}), do: B.boolean()
+  def convert({:type, _, :integer, []}), do: B.integer()
+  def convert({:type, _, :non_neg_integer, []}), do: B.non_neg_integer()
+  def convert({:type, _, :pos_integer, []}), do: B.pos_integer()
+  def convert({:type, _, :float, []}), do: B.float()
+  def convert({:type, _, :number, []}), do: B.number()
+  def convert({:type, _, :pid, []}), do: B.pid()
 
   # literals
-  def convert!({:atom, _, val}), do: B.literal(val)
-  def convert!({:integer, _, val}), do: B.literal(val)
+  def convert({:atom, _, val}), do: B.literal(val)
+  def convert({:integer, _, val}), do: B.literal(val)
 
-  def convert!({:type, _, :range, [{:integer, _, left}, {:integer, _, right}]}),
+  def convert({:type, _, :range, [{:integer, _, left}, {:integer, _, right}]}),
     do: B.range(left, right)
 
   # aliases
-  def convert!({:type, _, :term, []}), do: B.term()
-  def convert!({:type, _, :arity, []}), do: B.arity()
-  def convert!({:type, _, :module, []}), do: B.module()
-  def convert!({:type, _, :nonempty_binary, []}), do: B.nonempty_binary()
-  def convert!({:type, _, :nonempty_bitstring, []}), do: B.nonempty_bitstring()
-  def convert!({:type, _, :byte, []}), do: B.byte()
-  def convert!({:type, _, :char, []}), do: B.char()
-  def convert!({:type, _, :charlist, []}), do: B.charlist()
+  def convert({:type, _, :term, []}), do: B.term()
+  def convert({:type, _, :arity, []}), do: B.arity()
+  def convert({:type, _, :module, []}), do: B.module()
+  def convert({:type, _, :nonempty_binary, []}), do: B.nonempty_binary()
+  def convert({:type, _, :nonempty_bitstring, []}), do: B.nonempty_bitstring()
+  def convert({:type, _, :byte, []}), do: B.byte()
+  def convert({:type, _, :char, []}), do: B.char()
+  def convert({:type, _, :charlist, []}), do: B.charlist()
 
   # shothands for generics
-  def convert!({:type, _, :fun, [{:type, _, :any}, ret_type]}), do: B.function(convert!(ret_type))
-  def convert!({:type, _, :list, []}), do: B.list()
-  def convert!({:type, _, :nonempty_list, []}), do: B.nonempty_list()
-  def convert!({:type, _, :map, :any}), do: B.map()
+  def convert({:type, _, :fun, [{:type, _, :any}, ret_type]}), do: B.function(convert(ret_type))
+  def convert({:type, _, :list, []}), do: B.list()
+  def convert({:type, _, :nonempty_list, []}), do: B.nonempty_list()
+  def convert({:type, _, :map, :any}), do: B.map()
 
   # generics
-  def convert!({:type, _, :fun, [{:type, _, :product, arg_types}, ret_type]}),
-    do: B.function(Enum.map(arg_types, &convert!/1), convert!(ret_type))
+  def convert({:type, _, :fun, [{:type, _, :product, arg_types}, ret_type]}),
+    do: B.function(Enum.map(arg_types, &convert/1), convert(ret_type))
 
-  def convert!({:type, _, :list, [t]}), do: B.list(convert!(t))
+  def convert({:type, _, :bounded_fun, [t, _]}),
+    # TODO(@orsinium): can we support constraints?
+    do: convert(t)
 
-  def convert!({:type, 0, :tuple, types}),
-    do: B.fixed_tuple(Enum.map(types, &convert!/1))
+  def convert({:type, _, :list, [t]}), do: B.list(convert(t))
 
-  def convert!({:type, 0, :union, types}),
-    do: B.one_of(Enum.map(types, &convert!/1))
+  def convert({:type, 0, :tuple, types}),
+    do: B.fixed_tuple(Enum.map(types, &convert/1))
 
-  # remote types
+  def convert({:type, 0, :union, types}),
+    do: B.one_of(Enum.map(types, &convert/1))
 
-  def convert!({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :keyword}, []]}),
+  # elixir types
+
+  def convert({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :keyword}, []]}),
     do: B.keyword()
 
-  def convert!({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :keyword}, [t]]}),
-    do: B.keyword(convert!(t))
+  def convert({:remote_type, _, [{:atom, _, :elixir}, {:atom, _, :keyword}, [t]]}),
+    do: B.keyword(convert(t))
 
-  def convert!({:remote_type, _, [{:atom, _, :String}, {:atom, _, :t}, []]}),
+  def convert({:remote_type, _, [{:atom, _, :String}, {:atom, _, :t}, []]}),
     do: B.bitstring()
 
-  def convert!(_), do: raise("unsupported type")
+  def convert({:remote_type, _, [{:atom, _, :"List.Chars"}, {:atom, _, :t}, []]}),
+    do: B.charlist()
+
+  def convert(_), do: B.any()
 end

--- a/lib/type_check/internals/parser.ex
+++ b/lib/type_check/internals/parser.ex
@@ -1,8 +1,18 @@
 defmodule TypeCheck.Internals.Parser do
-  @moduledoc false
+  @moduledoc """
+  The parser for the default Elixir/Erlang `@spec`.
+
+  Experimental!
+  """
 
   alias TypeCheck.Builtin, as: B
 
+  @doc """
+  Extract raw spec for the given MFA.
+
+      iex> import TypeCheck.Internals.Parser
+      iex> {:ok, _} = fetch_spec(Kernel, :node, 1)
+  """
   @spec fetch_spec(atom() | list(), atom(), non_neg_integer()) ::
           {:error, String.t()} | {:ok, tuple()}
   def fetch_spec(module, function, arity) when is_atom(module) do
@@ -21,9 +31,18 @@ defmodule TypeCheck.Internals.Parser do
     end
   end
 
+  @doc """
+  Convert the raw spec extracted by `fetch_spec/3` into type_check type.
+
+      iex> import TypeCheck.Builtin
+      iex> import TypeCheck.Internals.Parser
+      iex> {:ok, spec} = fetch_spec(Kernel, :is_atom, 1)
+      iex> expected = function([term()], boolean())
+      iex> ^expected = convert(spec)
+  """
   # TODO(@orsinium):
   #  as_boolean
-  #  map(a, b),
+  #  map(a, b)
   #  mfa
   #  keyword(t)
   #  identifier

--- a/lib/type_check/internals/parser.ex
+++ b/lib/type_check/internals/parser.ex
@@ -23,12 +23,8 @@ defmodule TypeCheck.Internals.Parser do
 
   # TODO(@orsinium):
   #  as_boolean
-  #  bounded_fun
-  #  fun()
   #  map(a, b),
   #  mfa
-  #  no_return
-  #  none
   #  keyword(t)
   #  identifier
   #  sized bitstring
@@ -42,6 +38,8 @@ defmodule TypeCheck.Internals.Parser do
   def convert({:type, _, :bitstring, []}), do: B.bitstring()
   def convert({:type, _, :boolean, []}), do: B.boolean()
   def convert({:type, _, :pid, []}), do: B.pid()
+  def convert({:type, _, :no_return, []}), do: B.none()
+  def convert({:type, _, :none, []}), do: B.none()
 
   # unsupported by type_check yet
   def convert({:type, _, :reference, []}), do: B.any()
@@ -98,11 +96,9 @@ defmodule TypeCheck.Internals.Parser do
   def convert({:type, _, :nonempty_maybe_improper_list, [t, _tail]}),
     do: B.nonempty_list(convert(t))
 
-  def convert({:type, _, :tuple, types}),
-    do: B.fixed_tuple(Enum.map(types, &convert/1))
-
-  def convert({:type, _, :union, types}),
-    do: B.one_of(Enum.map(types, &convert/1))
+  def convert({:type, _, :tuple, types}), do: B.fixed_tuple(Enum.map(types, &convert/1))
+  def convert({:type, _, :union, types}), do: B.one_of(Enum.map(types, &convert/1))
+  def convert({:ann_type, _, [_var, t]}), do: convert(t)
 
   # elixir types
 

--- a/test/type_check/internals/parser_test.exs
+++ b/test/type_check/internals/parser_test.exs
@@ -1,0 +1,40 @@
+defmodule TypeCheck.Internals.ParserTest do
+  use ExUnit.Case, async: true
+
+  alias TypeCheck.Internals.Parser
+
+  # test that fetch_spec doesn't explode and all specs are supported
+  describe "fetch_spec smoke" do
+    for module <- [Kernel, String, List, Enum, DateTime] do
+      @module module
+      for {func, arity} <- module.__info__(:functions) do
+        @func func
+        @arity arity
+        test "#{module}.#{func}/#{arity}" do
+          r = Parser.fetch_spec(@module, @func, @arity)
+          refute match?({:error, "unsupported spec"}, r)
+        end
+      end
+    end
+  end
+
+  describe "convert smoke" do
+    for module <- [Kernel, String, List, Enum, DateTime] do
+      @module module
+      for {func, arity} <- module.__info__(:functions) do
+        @func func
+        @arity arity
+        test "#{module}.#{func}/#{arity}" do
+          case Parser.fetch_spec(@module, @func, @arity) do
+            {:ok, spec} ->
+              t = Parser.convert(spec)
+              assert %TypeCheck.Builtin.Function{} = t
+
+            {:error, _} ->
+              nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/type_check/internals/parser_test.exs
+++ b/test/type_check/internals/parser_test.exs
@@ -1,5 +1,6 @@
 defmodule TypeCheck.Internals.ParserTest do
   use ExUnit.Case, async: true
+  doctest TypeCheck.Internals.Parser
 
   alias TypeCheck.Internals.Parser
   alias TypeCheck.Builtin, as: B

--- a/test/type_check/internals/parser_test.exs
+++ b/test/type_check/internals/parser_test.exs
@@ -60,7 +60,8 @@ defmodule TypeCheck.Internals.ParserTest do
       {Kernel, :apply, 3, [B.module(), B.atom(), B.list()], B.any()},
       {Kernel, :exit, 1, [B.term()], B.none()},
       {Kernel, :function_exported?, 3, [B.module(), B.atom(), B.arity()], B.boolean()},
-      {Kernel, :get_in, 2, [B.any(), B.nonempty_list(B.term())], B.term()}
+      {Kernel, :get_in, 2, [B.any(), B.nonempty_list(B.term())], B.term()},
+      {Enum, :all?, 2, [B.any(), B.function([B.any()], B.as_boolean(B.term()))], B.boolean()}
     ]
 
     for {module, func, arity, exp_args, exp_result} <- cases do

--- a/test/type_check/internals/parser_test.exs
+++ b/test/type_check/internals/parser_test.exs
@@ -55,7 +55,11 @@ defmodule TypeCheck.Internals.ParserTest do
       {Kernel, :node, 1, [B.one_of([B.pid(), B.any(), B.any()])], B.atom()},
       {Kernel, :tl, 1, [B.nonempty_list()], B.one_of([B.list(), B.any()])},
       {Kernel, :tuple_size, 1, [B.tuple()], B.non_neg_integer()},
-      {Kernel, :apply, 2, [B.fun(), B.list()], B.any()}
+      {Kernel, :apply, 2, [B.fun(), B.list()], B.any()},
+      {Kernel, :apply, 3, [B.module(), B.atom(), B.list()], B.any()},
+      {Kernel, :exit, 1, [B.term()], B.none()},
+      {Kernel, :function_exported?, 3, [B.module(), B.atom(), B.arity()], B.boolean()},
+      {Kernel, :get_in, 2, [B.any(), B.nonempty_list(B.term())], B.term()}
     ]
 
     for {module, func, arity, exp_args, exp_result} <- cases do


### PR DESCRIPTION
We talked a bit at the meetup in ams and I said it would be great to support parsing for existing `@spec`, so it's easier to integrate type_check with third-party libraries. So, here you go. The PR introduces the parser for `@spec` that supports both Elixir and Erlang. It's not used anywhere just yet.

1. `fetch_spec` extracts the row spec for the given MFA
2. `convert` turns the raw spec into type_check type.

The parser is not used in any way yet. It's just there, waiting for someone to integrate it somewhere.