### PR TITLE
Credo

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Details:
         - It is not yet possible to combine them with fixed keys.
       Because of this, the inspection of the builtin type `map(key, value)` has been changed to look the same as an optional map. _This is a minor backwards-incompatible change._
     - Desugaring `%{}` has changed from 'any map' to 'the empty map' in line with Elixir's Typespecs. _This is a minor backwards-incompatible change._
+    - `TypeCheck.Credo.Check.Readability.Specs` is an opt-in alternative Credo check which will check whether all functions have either a `@spec!` or 'normal' `@spec`. (Fixes #102).
   
 - 0.10.8 - 
   - Fixes:

--- a/lib/type_check/credo/check/readability/specs.ex
+++ b/lib/type_check/credo/check/readability/specs.ex
@@ -1,8 +1,9 @@
 if Code.ensure_loaded?(Credo) do
-  defmodule TypeCheck.Credo.Checks.Readability.Specs do
+  defmodule TypeCheck.Credo.Check.Readability.Specs do
 
   use Credo.Check,
     tags: [:controversial],
+    category: :readability,
     param_defaults: [
       include_defp: false
     ],

--- a/lib/type_check/credo/checks/readability/specs.ex
+++ b/lib/type_check/credo/checks/readability/specs.ex
@@ -1,0 +1,181 @@
+if Code.ensure_loaded?(Credo) do
+  defmodule TypeCheck.Credo.Checks.Readability.Specs do
+
+  use Credo.Check,
+    tags: [:controversial],
+    param_defaults: [
+      include_defp: false
+    ],
+    explanations: [
+      check: """
+      Functions, callbacks and macros need typespecs.
+
+      Adding typespecs gives tools like Dialyzer and TypeCheck more information when performing
+      checks for type errors in function calls and definitions.
+      Typespecs will also be shown in generated documentation,
+      and can be a great way to concisely convey how a function should be used.
+
+      Using TypeCheck's `@spec!` syntax which will also enable runtime type-checking:
+      (Don't forget to `use TypeCheck` in your module!)
+
+          @spec! sub(integer, integer) :: integer
+          def sub(a, b), do: a + b
+
+      If you do not want runtime checks, write a normal `@spec`:
+
+          @spec add(integer, integer) :: integer
+          def add(a, b), do: a + b
+
+      Functions with multiple arities need to have a spec defined for each arity:
+
+          @spec! foo(integer) :: boolean
+          @spec! foo(integer, integer) :: boolean
+          def foo(a), do: a > 0
+          def foo(a, b), do: a > b
+
+      The check only considers whether the specification is present, it doesn't
+      perform any actual type checking while reading your code.
+
+      Like all `Readability` issues, this one is not a technical concern.
+      But you can improve the odds of others reading and liking your code by making
+      it easier to follow.
+      """,
+      params: [
+        include_defp: "Include private functions."
+      ]
+    ]
+
+
+  @moduledoc """
+  A custom Credo check which supports the `@spec!` syntax.
+
+  NOTE: This module is only compiled
+  if you've added `:credo` as a (dev/test) dependency to your app.
+
+  To use this check in your project, make sure you have a `.credo.exs` config file
+  (which you can generate with `mix credo gen.config`)
+  and make sure to add it to the `:checks` `:enabled` list:
+
+      %{
+        configs: [
+          %{
+            checks: %{
+              enabled:
+                [
+                  {#{__MODULE__}, []},
+                  # ...
+                ]
+                # ...
+              }
+            # ...
+          }
+        ]
+      }
+
+
+  This check is an alternative to Credo's own experimental `Credo.Check.Readability.Specs`,
+  so be sure to turn that check off.
+
+
+  ---
+
+  #{@moduledoc}
+  """
+
+  @doc false
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+    specs = Credo.Code.prewalk(source_file, &find_specs(&1, &2))
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, specs, issue_meta))
+  end
+
+  defp find_specs(
+    {speclike, _, [{:when, _, [{:"::", _, [{name, _, args}, _]}, _]} | _]} = ast,
+    specs
+  ) when speclike in [:spec, :spec!] do
+    {ast, [{name, length(args)} | specs]}
+  end
+
+  defp find_specs({speclike, _, [{_, _, [{name, _, args} | _]}]} = ast, specs)
+  when is_list(args) or is_nil(args) when speclike in [:spec, :spec!] do
+    args = with nil <- args, do: []
+    {ast, [{name, length(args)} | specs]}
+  end
+
+  defp find_specs({:impl, _, [impl]} = ast, specs) when impl != false do
+    {ast, [:impl | specs]}
+  end
+
+  defp find_specs({keyword, meta, [{:when, _, def_ast} | _]}, [:impl | specs])
+  when keyword in [:def, :defp] do
+    find_specs({keyword, meta, def_ast}, [:impl | specs])
+  end
+
+  defp find_specs({keyword, _, [{name, _, nil}, _]} = ast, [:impl | specs])
+  when keyword in [:def, :defp] do
+    {ast, [{name, 0} | specs]}
+  end
+
+  defp find_specs({keyword, _, [{name, _, args}, _]} = ast, [:impl | specs])
+  when keyword in [:def, :defp] do
+    {ast, [{name, length(args)} | specs]}
+  end
+
+  defp find_specs(ast, issues) do
+    {ast, issues}
+  end
+
+  # TODO: consider for experimental check front-loader (ast)
+  defp traverse(
+    {keyword, meta, [{:when, _, def_ast} | _]},
+    issues,
+    specs,
+    issue_meta
+  )
+  when keyword in [:def, :defp] do
+    traverse({keyword, meta, def_ast}, issues, specs, issue_meta)
+  end
+
+  defp traverse(
+    {keyword, meta, [{name, _, args} | _]} = ast,
+    issues,
+    specs,
+    issue_meta
+  )
+  when is_list(args) or is_nil(args) do
+    args = with nil <- args, do: []
+
+    if keyword not in enabled_keywords(issue_meta) or {name, length(args)} in specs do
+      {ast, issues}
+    else
+      {ast, [issue_for(issue_meta, meta[:line], name) | issues]}
+    end
+  end
+
+  defp traverse(ast, issues, _specs, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issue_for(issue_meta, line_no, trigger) do
+    format_issue(
+      issue_meta,
+      message: "Functions should have a @spec! or @spec type specification.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+
+  defp enabled_keywords(issue_meta) do
+    issue_meta
+    |> IssueMeta.params()
+    |> Params.get(:include_defp, __MODULE__)
+    |> case do
+         true -> [:def, :defp]
+         _ -> [:def]
+       end
+  end
+
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule TypeCheck.MixProject do
         ]
       _ ->
         [
-          extra_applications: [:logger, :iex, :stream_data]
+          extra_applications: [:logger, :iex, :stream_data, :credo]
         ]
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule TypeCheck.MixProject do
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},
       {:benchee, "~> 1.0", only: :bench},
       {:excoveralls, "~> 0.10", only: :test},
-      {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.5", runtime: false, optional: true},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
     ]
   end

--- a/test/type_check/credo/checks/readability/specs_test.exs
+++ b/test/type_check/credo/checks/readability/specs_test.exs
@@ -1,0 +1,305 @@
+defmodule TypeCheck.Credo.Checks.Readability.SpecsTest do
+  use Credo.Test.Case
+
+  @described_check TypeCheck.Credo.Check.Readability.Specs
+
+  describe "normal @spec attributes" do
+    test "it should NOT report functions with specs" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo(integer, integer) :: integer
+        @doc "some docs for foo/2"
+        def foo(a, b), do: a + b
+
+        @spec foo(integer) :: integer
+        def foo(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report functions with specs containing a `when` clause" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo(a, a) :: a when a: integer
+        @doc "some docs for foo/2"
+        def foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report private functions by default" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo(integer) :: integer
+        def foo(a), do: a
+
+        defp foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report private functions with specs when enabled" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo(integer) :: integer
+        def foo(a), do: a
+
+        @spec foo(integer) :: integer
+        defp foo(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, include_defp: true)
+      |> refute_issues()
+    end
+
+    test "it should report specs on private functions when enabled" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo(integer) :: integer
+        def foo(a), do: a
+
+        defp foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, include_defp: true)
+      |> assert_issue()
+    end
+
+    test "it should report functions without specs" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo(integer) :: integer
+        def foo(a), do: a
+
+        def foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue()
+    end
+
+    test "it should report specs with mismatched arity" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo(integer) :: integer
+        def foo(a), do: a
+
+        def foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue()
+    end
+
+    test "it should NOT report function with arity zero and a spec with no parentheses" do
+      """
+      defmodule CredoTypespecTest do
+        @spec foo :: :ok
+        def foo, do: :ok
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+  end
+
+  describe "TypeCheck @spec! attributes" do
+    test "it should NOT report functions with specs" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo(integer, integer) :: integer
+        @doc "some docs for foo/2"
+        def foo(a, b), do: a + b
+
+        @spec! foo(integer) :: integer
+        def foo(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report functions with specs containing a `when` clause" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo(a, a) :: a when a: integer
+        @doc "some docs for foo/2"
+        def foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report private functions by default" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo(integer) :: integer
+        def foo(a), do: a
+
+        defp foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report private functions with specs when enabled" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo(integer) :: integer
+        def foo(a), do: a
+
+        @spec foo(integer) :: integer
+        defp foo(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, include_defp: true)
+      |> refute_issues()
+    end
+
+    test "it should report specs on private functions when enabled" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo(integer) :: integer
+        def foo(a), do: a
+
+        defp foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check, include_defp: true)
+      |> assert_issue()
+    end
+
+    test "it should report functions without specs" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo(integer) :: integer
+        def foo(a), do: a
+
+        def foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue()
+    end
+
+    test "it should report specs with mismatched arity" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo(integer) :: integer
+        def foo(a), do: a
+
+        def foo(a, b), do: a + b
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue()
+    end
+
+    test "it should NOT report function with arity zero and a spec with no parentheses" do
+      """
+      defmodule CredoTypespecTest do
+        @spec! foo :: :ok
+        def foo, do: :ok
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+  end
+
+
+    test "it should NOT report functions with `@impl true`" do
+      """
+      defmodule CredoTypespecTest do
+        @impl true
+        def foo(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report functions with guards and `@impl true`" do
+      """
+      defmodule CredoTypespecTest do
+        @impl true
+        def foo(a) when is_integer(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report functions without arguments and `@impl true`" do
+      """
+      defmodule CredoTypespecTest do
+        @impl true
+        def foo, do: :ok
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should NOT report functions with `@impl SomeMod`" do
+      """
+      defmodule CredoTypespecTest do
+        @impl SomeMod
+        def foo(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> refute_issues()
+    end
+
+    test "it should report functions with `@impl false`" do
+      """
+      defmodule CredoTypespecTest do
+        @impl false
+        def foo(a), do: a
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue()
+    end
+
+    test "it should report function with arity zero and no parentheses" do
+      """
+      defmodule CredoTypespecTest do
+        def foo, do: :ok
+      end
+      """
+      |> to_source_file()
+      |> run_check(@described_check)
+      |> assert_issue()
+    end
+end


### PR DESCRIPTION
- [x] Custom Credo check which checks for both `@spec` or `@spec!`
- [x] A nice description on how to use it as well as a clear explanation in the check.
- [x] Tests

The check and usage of Credo in general is of course opt-in.

Fixes #102 

