### PR TITLE
Compound fixed map syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,16 @@ Details:
 ### Changelog
 - 0.11.0 - 
   Additions:
-    - Basic support `%{required(key_type) => value_type}` and `%{optional(key_type) => value_type}` syntaxes using the new `TypeCheck.Builtin.fancy_map` function.
-      Still has some limitations:
-        - Only a single required or optional can be used per map. 
-        - It is not yet possible to combine them with fixed keys.
-      Because of this, the inspection of the builtin type `map(key, value)` has been changed to look the same as an optional map. _This is a minor backwards-incompatible change._
+    - Support for fancier map syntaxes:
+      - `%{required(key_type) => value_type}` Maps with a single kind of required key-value type.
+      - `%{optional(key_type) => value_type}` Maps with a single kind of optional key-value type.
+      - `%{:some => a(), :fixed => b(), :keys => c(), optional(atom()) => any()}` Maps with any number of fixed keys and a single optional key-value type.
+      - TypeCheck now supports nearly all kinds of map types that see use. Archaic combinations of optional and required are not supported, but also not very useful types in practice.
+      - Because of this, the inspection of the builtin type `map(key, value)` has been changed to look the same as an optional map. _This is a minor backwards-incompatible change._
     - Desugaring `%{}` has changed from 'any map' to 'the empty map' in line with Elixir's Typespecs. _This is a minor backwards-incompatible change._
-    - Support for `port()`, `reference()` and `identifier()`.
-  
+    - Support for the builtin types `port()`, `reference()` and (based on these) `identifier()`.
+    - Support for the builtin type `struct()`.
+    - Improvements to the default type overrides for modules like `Calendar`, `Enum`, `Enumerable`, etc. now that optional keys in struct types and higher-order function types are supported.
 - 0.10.8 - 
   - Fixes:
     - Ensures that the `Inspect` protocol is properly implemented for sized bitstring types (c.f. #104). Thank you very much, @trarbr!

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -855,8 +855,24 @@ defmodule TypeCheck.Builtin do
 
   @doc typekind: :extension
   @doc """
-  WIP
+  Allows constructing map types containing a combination of fixed, required and optional keys (and their associatied type-values)
+
+  Desugaring of most ways of map syntaxes.
+
+  Note that because of reasons of efficiency and implementation difficulty,
+  not all possibilities are supported by TypeCheck currently.
+
+  Supported are:
+  - maps with only fixed keys (`%{a: 1, b: 2, "foo" => number()}`)
+  - maps with a single required keypair (`%{required(key_type) => value_type}`)
+  - maps with a single optional keypair (`%{optional(key_type) => value_type}`)
+  - maps with only fixed keys and one optional keypair (`%{:a => 1, :b => 2, "foo" => number(), optional(integer()) => boolean()}`)
+
+  Help with extending this support is very welcome.
+  c.f. https://github.com/Qqwy/elixir-type_check/issues/7
   """
+  @spec fancy_map(fixed_kvs :: list({term(), TypeCheck.Type.t()}), required_kvs :: list({TypeCheck.Type.t(), TypeCheck.Type.t()}), optional_kvs :: list({TypeCheck.Type.t(), TypeCheck.Type.t()})) :: TypeCheck.Builtin.CompoundFixedMap.t() | TypeCheck.Builtin.FixedMap.t() | TypeCheck.Builtin.Map.t() | TypeCheck.Builtin.NamedType.t()
+  def fancy_map(fixed_kvs, required_kvs, optional_kvs)
   def fancy_map(fixed_keypairs, [], []) do
     fixed_map(fixed_keypairs)
   end
@@ -893,12 +909,13 @@ defmodule TypeCheck.Builtin do
     TODO!
     Maps with complex combinations of multiple
     fixed and/or required(...) and/or optional(...) keypairs
-    are not supported by TypeCheck yet.
+    are not currently supported by TypeCheck.
 
     Supported are:
     - maps with only fixed keys (`%{a: 1, b: 2, "foo" => number()}`)
     - maps with a single required keypair (`%{required(key_type) => value_type}`)
     - maps with a single optional keypair (`%{optional(key_type) => value_type}`)
+    - maps with only fixed keys and one optional keypair (`%{:a => 1, :b => 2, "foo" => number(), optional(integer()) => boolean()}`)
 
     Help with extending this support is very welcome.
     c.f. https://github.com/Qqwy/elixir-type_check/issues/7

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -905,6 +905,16 @@ defmodule TypeCheck.Builtin do
     """
   end
 
+  @doc typekind: :builtin
+  @doc """
+  Any kind of struct.
+
+  Syntactic sugar for %{:__struct__ => atom(), optional(atom()) => any()}
+  """
+  def struct() do
+    fancy_map([__struct__: atom()], [], [{atom(), any()}])
+  end
+
   @doc typekind: :extension
   @doc """
   A list of fixed size where `element_types` dictates the types

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -871,7 +871,10 @@ defmodule TypeCheck.Builtin do
   Help with extending this support is very welcome.
   c.f. https://github.com/Qqwy/elixir-type_check/issues/7
   """
-  @spec fancy_map(fixed_kvs :: list({term(), TypeCheck.Type.t()}), required_kvs :: list({TypeCheck.Type.t(), TypeCheck.Type.t()}), optional_kvs :: list({TypeCheck.Type.t(), TypeCheck.Type.t()})) :: TypeCheck.Builtin.CompoundFixedMap.t() | TypeCheck.Builtin.FixedMap.t() | TypeCheck.Builtin.Map.t() | TypeCheck.Builtin.NamedType.t()
+
+  if_recompiling? do
+    @spec fancy_map(fixed_kvs :: list({term(), TypeCheck.Type.t()}), required_kvs :: list({TypeCheck.Type.t(), TypeCheck.Type.t()}), optional_kvs :: list({TypeCheck.Type.t(), TypeCheck.Type.t()})) :: TypeCheck.Builtin.CompoundFixedMap.t() | TypeCheck.Builtin.FixedMap.t() | TypeCheck.Builtin.Map.t() | TypeCheck.Builtin.NamedType.t()
+  end
   def fancy_map(fixed_kvs, required_kvs, optional_kvs)
   def fancy_map(fixed_keypairs, [], []) do
     fixed_map(fixed_keypairs)

--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -866,13 +866,26 @@ defmodule TypeCheck.Builtin do
   end
 
   def fancy_map([], [{required_key_type, value_type}], []) do
+    required_map(required_key_type, value_type)
+  end
+
+  defp required_map(required_key_type, value_type) do
     guard =
       quote do
-        map_size(unquote(Macro.var(:map, nil))) >= 1
-      end
+      map_size(unquote(Macro.var(:map, nil))) >= 1
+    end
 
     named_type(:map, map(required_key_type, value_type))
     |> guarded_by(guard)
+  end
+
+  def fancy_map(fixed_keypairs, [], [{optional_key_type, value_type}]) do
+    fixed = fixed_map(fixed_keypairs)
+    flexible = map(optional_key_type, value_type)
+
+    build_struct(TypeCheck.Builtin.CompoundFixedMap)
+    |> Map.put(:fixed, fixed)
+    |> Map.put(:flexible, flexible)
   end
 
   def fancy_map(_fixed_keypairs, _required_keypairs, _optional_keypairs) do

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -22,7 +22,7 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s = %TypeCheck.Builtin.CompoundFixedMap{}, param) do
-      # NOTE: We cannot use Keyword here since the keys are not atoms but arbitrary values
+      # NOTE: We cannot use Keyword.keys here since the keys are not atoms but arbitrary values
       fixed_keys = s.fixed.keypairs |> Enum.map(fn {key, _val} -> key end)
       fixed_part_var = Macro.var(:fixed_part, __MODULE__)
       flexible_part_var = Macro.var(:flexible_part, __MODULE__)

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -87,4 +87,18 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
       is_atom(val) and !match?('Elixir.' ++ _, Atom.to_charlist(val))
     end
   end
+
+
+  if Code.ensure_loaded?(StreamData) do
+    defimpl TypeCheck.Protocols.ToStreamData do
+      def to_gen(s) do
+        fixed_gen = TypeCheck.Protocols.ToStreamData.to_gen(s.fixed)
+        flexible_gen = TypeCheck.Protocols.ToStreamData.to_gen(s.flexible)
+
+        StreamData.map({fixed_gen, flexible_gen}, fn {fixed_map, flexible_map} ->
+          Map.merge(fixed_map, flexible_map)
+        end)
+      end
+    end
+  end
 end

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -1,0 +1,79 @@
+defmodule TypeCheck.Builtin.CompoundFixedMap do
+  @moduledoc """
+  Special type for map-typespecs that contain a combination of fixed keys as well as an `optional(...)` or `required(...)` part.
+
+  Its checks compile down to a combination of `TypeCheck.Builtin.FixedMap` and `TypeCheck.Builtin.Map`
+  for the fixed resp. non-fixed parts.
+  """
+
+  defstruct [:fixed, :flexible]
+
+  use TypeCheck
+  @type! t :: %__MODULE__{fixed: TypeCheck.Builtin.FixedMap.t(), flexible: TypeCheck.Builtin.Map.t()}
+
+  @type! problem_tuple :: TypeCheck.Builtin.FixedMap.problem_tuple() | TypeCheck.Builtin.Map.problem_tuple()
+
+  defimpl TypeCheck.Protocols.ToCheck do
+    def to_check(s = %TypeCheck.Builtin.CompoundFixedMap{}, param) do
+      # NOTE: We cannot use Keyword here since the keys are not atoms but arbitrary values
+      fixed_keys = s.fixed.keypairs |> Enum.map(fn {key, _val} -> key end)
+      fixed_part_var = Macro.var(:fixed_Part, __MODULE__)
+      flexible_part_var = Macro.var(:fixed_Part, __MODULE__)
+
+      res =
+        quote generated: :true, location: :keep do
+        compound_map = unquote(param)
+          with {:ok, _, _} <- map_check(compound_map, s),
+            {unquote(fixed_part_var), unquote(flexible_part_var)} = Map.split(compound_map, unquote(fixed_keys)),
+               {:ok, bindings1, fixed_part} <- unquote(TypeCheck.Protocols.ToCheck.to_check(s.fixed, fixed_part_var)),
+               {:ok, bindings2, flexible_part} <- unquote(TypeCheck.Protocols.ToCheck.to_check(s.flexible, flexible_part_var))
+            do
+            {:ok, bindings1 ++ bindings2, Map.merge(fixed_part, flexible_part)}
+          end
+        end
+
+      res
+    end
+
+    defp map_check(param, s) do
+      quote generated: true, location: :keep do
+        case unquote(param) do
+          val when is_map(val) ->
+            {:ok, [], val}
+          other ->
+            {:error, {unquote(Macro.escape(s)), :not_a_map, %{}, other}}
+        end
+      end
+    end
+  end
+
+
+  defimpl TypeCheck.Protocols.Inspect do
+    def inspect(s, opts) do
+      fixed_keypairs_str = Inspect.Algebra.container_doc("%{", s.fixed.keypairs, "", opts, &to_map_kv(&1, &2), separator: ",", break: :strict)
+
+      flexible_key_str = TypeCheck.Protocols.Inspect.inspect(s.flexible.key_type, opts)
+      flexible_val_str = TypeCheck.Protocols.Inspect.inspect(s.flexible.value_type, opts)
+      flexible_str = Inspect.Algebra.concat(["optional(", flexible_key_str, ") => ", flexible_val_str])
+
+      Inspect.Algebra.concat([fixed_keypairs_str, ", ", flexible_str, "}"])
+    end
+
+    defp to_map_kv({key, value_type}, opts) do
+      import Inspect.Algebra, only: [color: 3, concat: 2, to_doc: 2]
+      value_doc = TypeCheck.Protocols.Inspect.inspect(value_type, opts)
+
+      if non_module_atom?(key) do
+        key = color(Code.Identifier.inspect_as_key(key), :atom, opts)
+        concat(key, concat(" ", value_doc))
+      else
+        sep = color(" =>", :map, opts)
+        concat(concat(to_doc(key, opts), sep), value_doc)
+      end
+    end
+
+    defp non_module_atom?(val) do
+      is_atom(val) and !match?('Elixir.' ++ _, Atom.to_charlist(val))
+    end
+  end
+end

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -59,14 +59,14 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
 
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(s, opts) do
-      import Inspect.Algebra, only: [color: 3, concat: 1, container_doc: 6]
-      fixed_keypairs_str = container_doc("%{", s.fixed.keypairs, "", opts, &to_map_kv(&1, &2), separator: color(",", :map, opts), break: :strict)
+      import Inspect.Algebra, only: [color: 3, concat: 1, container_doc: 6, group: 1, break: 1]
+      fixed_keypairs_str = container_doc("", s.fixed.keypairs, "", opts, &to_map_kv(&1, &2), separator: color(",", :map, opts), break: :strict)
 
       flexible_key_str = TypeCheck.Protocols.Inspect.inspect(s.flexible.key_type, opts)
       flexible_val_str = TypeCheck.Protocols.Inspect.inspect(s.flexible.value_type, opts)
       flexible_str = concat([color("optional(", :map, opts), flexible_key_str, color(") => ", :map, opts), flexible_val_str])
 
-      concat([fixed_keypairs_str, color(", ", :map, opts), flexible_str, color("}", :map, opts)])
+      concat([color("%{", :map, opts), break(""), group(concat([flexible_str, color(", ", :map, opts), fixed_keypairs_str])), color("}", :map, opts)])
       |> color(:map, opts)
     end
 
@@ -87,7 +87,6 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
       is_atom(val) and !match?('Elixir.' ++ _, Atom.to_charlist(val))
     end
   end
-
 
   if Code.ensure_loaded?(StreamData) do
     defimpl TypeCheck.Protocols.ToStreamData do

--- a/lib/type_check/default_overrides/access.ex
+++ b/lib/type_check/default_overrides/access.ex
@@ -5,7 +5,10 @@ defmodule TypeCheck.DefaultOverrides.Access do
 
   @type! any_container() :: any()
 
-  @type! container() :: keyword() | struct() | map()
+  # TODO
+  @type container() :: keyword() | struct() | map()
+  @autogen_typespec false
+  @type! container() :: keyword() | map()
 
   @type! get_and_update_fun(data, current_value) ::
   (:get_and_update, data, (term() -> term()) ->

--- a/lib/type_check/default_overrides/access.ex
+++ b/lib/type_check/default_overrides/access.ex
@@ -5,23 +5,14 @@ defmodule TypeCheck.DefaultOverrides.Access do
 
   @type! any_container() :: any()
 
-  # TODO
-  @type container() :: keyword() | struct() | map()
-  @autogen_typespec false
-  @type! container() :: keyword() | map()
+  @type! container() :: keyword() | struct() | map()
 
-  # TODO
-  @type get_and_update_fun(data, current_value) ::
+  @type! get_and_update_fun(data, current_value) ::
   (:get_and_update, data, (term() -> term()) ->
     {current_value, new_data :: container()} | :pop)
-  @autogen_typespec false
-  @type! get_and_update_fun(data, current_value) :: function()
 
-  # TODO
-  @type get_fun(data) ::
+  @type! get_fun(data) ::
   (:get, data, (term() -> term()) -> new_data :: container())
-  @autogen_typespec false
-  @type! get_fun(data) :: function()
 
   @type! key() :: any()
 

--- a/lib/type_check/default_overrides/calendar.ex
+++ b/lib/type_check/default_overrides/calendar.ex
@@ -9,6 +9,7 @@ defmodule TypeCheck.DefaultOverrides.Calendar do
   @autogen_typespec false
   @type! calendar() :: Elixir.Calendar.ISO
 
+  # TODO
   @type! date() :: %{
     # optional(any()) => any(),
     :calendar => calendar(),
@@ -17,6 +18,7 @@ defmodule TypeCheck.DefaultOverrides.Calendar do
     :day => day()
   }
 
+  # TODO
   @type! datetime() :: %{
     # optional(any()) => any(),
     :calendar => calendar(),
@@ -56,6 +58,7 @@ defmodule TypeCheck.DefaultOverrides.Calendar do
 
   @type! month() :: pos_integer()
 
+  # TODO
   @type! naive_datetime() :: %{
     # optional(any()) => any(),
     :calendar => calendar(),
@@ -72,6 +75,7 @@ defmodule TypeCheck.DefaultOverrides.Calendar do
 
   @type! std_offset() :: integer()
 
+  # TODO
   @type! time() :: %{
     # optional(any()) => any(),
     :hour => hour(),

--- a/lib/type_check/default_overrides/calendar.ex
+++ b/lib/type_check/default_overrides/calendar.ex
@@ -9,18 +9,16 @@ defmodule TypeCheck.DefaultOverrides.Calendar do
   @autogen_typespec false
   @type! calendar() :: Elixir.Calendar.ISO
 
-  # TODO
   @type! date() :: %{
-    # optional(any()) => any(),
+    optional(any()) => any(),
     :calendar => calendar(),
     :year => year(),
     :month => month(),
     :day => day()
   }
 
-  # TODO
   @type! datetime() :: %{
-    # optional(any()) => any(),
+    optional(any()) => any(),
     :calendar => calendar(),
     :year => year(),
     :month => month(),
@@ -58,9 +56,8 @@ defmodule TypeCheck.DefaultOverrides.Calendar do
 
   @type! month() :: pos_integer()
 
-  # TODO
   @type! naive_datetime() :: %{
-    # optional(any()) => any(),
+    optional(any()) => any(),
     :calendar => calendar(),
     :year => year(),
     :month => month(),
@@ -75,9 +72,8 @@ defmodule TypeCheck.DefaultOverrides.Calendar do
 
   @type! std_offset() :: integer()
 
-  # TODO
   @type! time() :: %{
-    # optional(any()) => any(),
+    optional(any()) => any(),
     :hour => hour(),
     :minute => minute(),
     :second => second(),

--- a/lib/type_check/default_overrides/enumerable.ex
+++ b/lib/type_check/default_overrides/enumerable.ex
@@ -2,25 +2,16 @@ defmodule TypeCheck.DefaultOverrides.Enumerable do
   use TypeCheck
   @type! acc() :: {:cont, term()} | {:halt, term()} | {:suspend, term()}
 
-  # TODO
-  @type continuation() :: (acc() -> result())
-  @autogen_typespec false
-  @type! continuation() :: function()
+  @type! continuation() :: (acc() -> result())
 
-  # TODO
-  @type reducer() :: (element :: term(), current_acc :: acc() -> updated_acc :: acc())
-  @autogen_typespec false
-  @type! reducer() :: function()
+  @type! reducer() :: (element :: term(), current_acc :: acc() -> updated_acc :: acc())
 
   @type! result() ::
   {:done, term()}
   | {:halted, term()}
   | {:suspended, term(), continuation()}
 
-  # TODO
-  @type slicing_fun() :: (start :: non_neg_integer(), length :: pos_integer() -> [term()])
-  @autogen_typespec false
-  @type! slicing_fun() :: function()
+  @type! slicing_fun() :: (start :: non_neg_integer(), length :: pos_integer() -> [term()])
 
   @type! t() :: impl(Elixir.Enumerable)
 end

--- a/lib/type_check/default_overrides/erlang/binary.ex
+++ b/lib/type_check/default_overrides/erlang/binary.ex
@@ -1,10 +1,7 @@
 # Overrides Erlang's `:binary` module:
 defmodule Elixir.TypeCheck.DefaultOverrides.Erlang.Binary do
   use TypeCheck
-  # TODO
-  @opaque cp() :: {any(), reference()}
-  @autogen_typespec false
-  @opaque! cp() :: {:am | :bm, term()}
+  @opaque! cp() :: {:am | :bm, reference()}
 
   @opaque! part() :: {start :: non_neg_integer(), length :: integer()}
 end

--- a/lib/type_check/default_overrides/exception.ex
+++ b/lib/type_check/default_overrides/exception.ex
@@ -14,10 +14,9 @@ defmodule TypeCheck.DefaultOverrides.Exception do
   {module(), atom(), arity_or_args(), location()}
   | {(... -> any()), arity_or_args(), location()}
 
-  # TODO
   @type! t() :: %{
     :__struct__ => module(),
     :__exception__ => true,
-    # optional(atom()) => any()
+    optional(atom()) => any()
   }
 end

--- a/lib/type_check/default_overrides/exception.ex
+++ b/lib/type_check/default_overrides/exception.ex
@@ -6,17 +6,13 @@ defmodule TypeCheck.DefaultOverrides.Exception do
 
   @type! location() :: keyword()
 
-  # TODO
-  @type non_error_kind() :: :exit | :throw | {:EXIT, pid()}
-  @autogen_typespec false
-  @type! non_error_kind() :: :exit | :throw | {:EXIT, term()}
+  @type! non_error_kind() :: :exit | :throw | {:EXIT, pid()}
 
   @type! stacktrace() :: [stacktrace_entry()]
 
-  # TODO
   @type! stacktrace_entry() ::
   {module(), atom(), arity_or_args(), location()}
-  | {function(), arity_or_args(), location()}
+  | {(... -> any()), arity_or_args(), location()}
 
   # TODO
   @type! t() :: %{

--- a/lib/type_check/default_overrides/exception.ex
+++ b/lib/type_check/default_overrides/exception.ex
@@ -14,6 +14,7 @@ defmodule TypeCheck.DefaultOverrides.Exception do
   {module(), atom(), arity_or_args(), location()}
   | {(... -> any()), arity_or_args(), location()}
 
+  # TODO
   @type! t() :: %{
     :__struct__ => module(),
     :__exception__ => true,

--- a/lib/type_check/default_overrides/io.ex
+++ b/lib/type_check/default_overrides/io.ex
@@ -7,8 +7,7 @@ defmodule TypeCheck.DefaultOverrides.IO do
   # @type chardata() :: String.t() | maybe_improper_list(char() | chardata(), String.t() | [])
   # @type! chardata() :: String.t() | maybe_improper_list(char() | chardata(), String.t() | [])
 
-  # TODO
-  # @type! device() :: atom() | pid()
+  @type! device() :: atom() | pid()
 
   @type! nodata() :: {:error, term()} | :eof
 end

--- a/lib/type_check/default_overrides/version.ex
+++ b/lib/type_check/default_overrides/version.ex
@@ -10,12 +10,10 @@ defmodule TypeCheck.DefaultOverrides.Version do
 
   @type! patch() :: non_neg_integer()
 
-  # TODO
   @type! pre() :: [String.t() | non_neg_integer()]
 
   @type! requirement() :: String.t() | Version.Requirement.t()
 
-  # TODO
   @type! t() :: %Elixir.Version{
     build: build(),
     major: major(),

--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -237,8 +237,8 @@ defmodule TypeCheck.Internals.PreExpander do
           TypeCheck.Builtin.range(unquote(orig_ast))
         end
 
-      nil ->
-        # Any other kind of map type.
+      _other ->
+        # Any other kind of map or possibly struct type, which might include optional or required keys.
         field_types =
           Enum.reduce(struct_fields, %{fixed: [], required: [], optional: []}, fn
             {{:required, _, [key_type]}, value_type}, acc ->
@@ -267,12 +267,12 @@ defmodule TypeCheck.Internals.PreExpander do
             TypeCheck.Builtin.fancy_map(unquote(field_types.fixed), unquote(field_types.required), unquote(field_types.optional))
           end
 
-      _other ->
-        # Unhandled already-expanded structs
-        # Treat them as literal values
-        quote generated: true, location: :keep do
-          TypeCheck.Builtin.literal(unquote(orig_ast))
-        end
+      # _other ->
+      #   # Unhandled already-expanded structs
+      #   # Treat them as literal values
+      #   quote generated: true, location: :keep do
+      #     TypeCheck.Builtin.literal(unquote(orig_ast))
+      #   end
     end
   end
 

--- a/lib/type_check/protocols/inspect.ex
+++ b/lib/type_check/protocols/inspect.ex
@@ -14,6 +14,7 @@ structs = [
   TypeCheck.Builtin.Binary,
   TypeCheck.Builtin.Bitstring,
   TypeCheck.Builtin.Boolean,
+  TypeCheck.Builtin.CompoundFixedMap,
   TypeCheck.Builtin.Guarded,
   TypeCheck.Builtin.FixedMap,
   TypeCheck.Builtin.FixedList,

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -80,12 +80,12 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
     compound_check(val, s, "at index #{index}:\n", do_format(problem))
   end
 
-  def do_format({s = %TypeCheck.Builtin.FixedMap{}, :not_a_map, _, val}) do
+  def do_format({s = %maplike{}, :not_a_map, _, val}) when maplike in [TypeCheck.Builtin.FixedMap, TypeCheck.Builtin.CompoundFixedMap] do
     problem = "`#{inspect(val, inspect_value_opts())}` is not a map."
     compound_check(val, s, problem)
   end
 
-  def do_format({s = %TypeCheck.Builtin.FixedMap{}, :missing_keys, %{keys: keys}, val}) do
+  def do_format({s = %maplike{}, :missing_keys, %{keys: keys}, val}) when maplike in [TypeCheck.Builtin.FixedMap, TypeCheck.Builtin.CompoundFixedMap] do
     keys_str =
       keys
       |> Enum.map(&inspect/1)
@@ -96,7 +96,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
     compound_check(val, s, problem)
   end
   
-  def do_format({s = %TypeCheck.Builtin.FixedMap{}, :superfluous_keys, %{keys: keys}, val}) do
+  def do_format({s = %maplike{}, :superfluous_keys, %{keys: keys}, val}) when maplike in [TypeCheck.Builtin.FixedMap, TypeCheck.Builtin.CompoundFixedMap] do
     keys_str =
       keys
       |> Enum.map(&inspect/1)
@@ -109,8 +109,8 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
   end
 
   def do_format(
-        {s = %TypeCheck.Builtin.FixedMap{}, :value_error, %{problem: problem, key: key}, val}
-      ) do
+        {s = %maplike{}, :value_error, %{problem: problem, key: key}, val}
+  ) when maplike in [TypeCheck.Builtin.FixedMap, TypeCheck.Builtin.CompoundFixedMap] do
     compound_check(val, s, "under key `#{inspect(key, inspect_type_opts())}`:\n", do_format(problem))
   end
 
@@ -176,7 +176,7 @@ defmodule TypeCheck.TypeError.DefaultFormatter do
     compound_check(val, s, "`#{inspect(val, inspect_value_opts())}` is not a map.")
   end
 
-  def do_format({s = %TypeCheck.Builtin.Map{}, :key_error, %{problem: problem}, val}) do
+  def do_format({s = %maplike{}, :key_error, %{problem: problem}, val}) when maplike in [TypeCheck.Builtin.Map, TypeCheck.Builtin.CompoundFixedMap] do
     compound_check(val, s, "key error:\n", do_format(problem))
   end
 

--- a/lib/type_check/type_error/formatter.ex
+++ b/lib/type_check/type_error/formatter.ex
@@ -34,6 +34,7 @@ defmodule TypeCheck.TypeError.Formatter do
          | TypeCheck.Builtin.Boolean.problem_tuple()
          | TypeCheck.Builtin.FixedList.problem_tuple()
          | TypeCheck.Builtin.FixedMap.problem_tuple()
+         | TypeCheck.Builtin.CompoundFixedMap.problem_tuple()
          | TypeCheck.Builtin.FixedTuple.problem_tuple()
          | TypeCheck.Builtin.Float.problem_tuple()
          | TypeCheck.Builtin.Integer.problem_tuple()

--- a/test/type_check/builtin_test.exs
+++ b/test/type_check/builtin_test.exs
@@ -35,6 +35,9 @@ defmodule TypeCheck.BuiltinTest do
         %{a: 1, b: integer()}
       end => TypeCheck.Builtin.FixedMap,
       quote do
+        %{optional(number()) => boolean(), a: 1, b: integer()}
+      end => TypeCheck.Builtin.CompoundFixedMap,
+      quote do
         {1, float()}
       end => TypeCheck.Builtin.FixedTuple,
       quote do


### PR DESCRIPTION
- [x] Support for map syntax of the style `%{:some => a(), :fixed => b(), :keys => c(), optional(atom()) => any()}`.
- [x] Tests for this.
- [x] StreamData generator for this.
- [x] Builtin `struct()` type based on this.
- [x] Overrides for the types of `Calendar` etc. based on this
- [x] Updated Changelog with these changes.