### PR TITLE
Hide bindings from opaque types

### DIFF
--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -1074,13 +1074,14 @@ defmodule TypeCheck.Builtin do
   if_recompiling? do
     # @spec! named_type(name :: atom() | String.t(), type :: TypeCheck.Type.t()) :: TypeCheck.Builtin.NamedType.t()
   end
-  def named_type(name, type) do
+  def named_type(name, type, type_kind \\ :type) do
     TypeCheck.Type.ensure_type!(type)
 
     build_struct(TypeCheck.Builtin.NamedType)
     |> Map.put(:name, name)
     |> Map.put(:type, type)
     |> Map.put(:local, true)
+    |> Map.put(:type_kind, type_kind)
   end
 
   @doc typekind: :extension

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -13,7 +13,11 @@ defmodule TypeCheck.Builtin.Guarded do
   @doc false
   def extract_names(type) do
     case type do
-      %TypeCheck.Builtin.NamedType{} ->
+      # Do not extract names across non-local types
+      %TypeCheck.Builtin.NamedType{local: false} ->
+        []
+
+      %TypeCheck.Builtin.NamedType{local: true} ->
         [type.name | extract_names(type.type)]
 
       %TypeCheck.Builtin.FixedList{} ->

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -16,8 +16,8 @@ defmodule TypeCheck.Builtin.NamedType do
     def to_check(s, param) do
       inner_check = TypeCheck.Protocols.ToCheck.to_check(s.type, param)
 
-      if s.type_kind == :opaque do
-        # Do not expose binding on opaque types
+      if !s.local do
+        # Do not expose bindings across non-local types
         quote generated: true, location: :keep do
           inner_res = unquote(inner_check)
           case inner_res do

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -501,7 +501,7 @@ defmodule TypeCheck.Macros do
         {name, _, params} when is_list(params) -> {name, length(params)}
       end
 
-    res = type_fun_definition(name_with_maybe_params, type, caller.module, typecheck_options.overrides)
+    res = type_fun_definition(name_with_maybe_params, type, caller.module, typecheck_options.overrides, kind)
 
     quote generated: true, location: :keep do
       if Module.get_attribute(__MODULE__, :autogen_typespec) do
@@ -567,7 +567,7 @@ defmodule TypeCheck.Macros do
     end
   end
 
-  defp type_fun_definition(name_with_params, type, module_name, overrides) do
+  defp type_fun_definition(name_with_params, type, module_name, overrides, kind) do
     {_name, params} = Macro.decompose_call(name_with_params)
 
     params_check_code =
@@ -597,7 +597,7 @@ defmodule TypeCheck.Macros do
         unquote_splicing(params_check_code)
         # import TypeCheck.Builtin
         unquote(type_expansion_loop_prevention_code(name_with_params))
-        TypeCheck.Builtin.named_type(unquote(pretty_type_name), unquote(type)) |> Map.put(:local, false)
+        TypeCheck.Builtin.named_type(unquote(pretty_type_name), unquote(type), unquote(kind)) |> Map.put(:local, false)
       end
     end
   end

--- a/test/type_check/builtin/named_type_test.exs
+++ b/test/type_check/builtin/named_type_test.exs
@@ -1,0 +1,17 @@
+defmodule TypeCheck.Builtin.NamedTypeTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+  import StreamData, only: []
+  use TypeCheck
+
+  # defmodule Example do
+  #   use TypeCheck, debug: true
+
+  #   @opaque! secret() :: fancy :: binary()
+  #   @type! known :: (foo :: %{a: number(), b: secret()} when is_map(fancy))
+
+  #   @spec! foo() :: known()
+  #   def foo() do
+  #   end
+  # end
+end

--- a/test/type_check/builtin/named_type_test.exs
+++ b/test/type_check/builtin/named_type_test.exs
@@ -19,7 +19,7 @@ defmodule TypeCheck.Builtin.NamedTypeTest do
     import ExUnit.CaptureIO
     capture_io(:stderr, fn ->
     assert_raise(CompileError,
-      "lib/type_check/spec.ex:28: undefined function hidden/0 (expected TypeCheck.Builtin.NamedTypeTest.BadExample to define such a function or for it to be imported, but none are available)",
+      ~r"lib/type_check/spec.ex:28: undefined function hidden/0",
       fn ->
       defmodule BadExample do
         use TypeCheck


### PR DESCRIPTION
Names used inside ~~opaque~~ _any_ types should not escape its scope.

Fixes #4 