### PR TITLE
Silence Dialyzer by adding TypeCheck.Spec.problem_tuple() to TypeCheck.TypeError.Formatter.problem_tuple()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
           mix deps.compile
       - run: mix compile
       # - run: mix test # Testing is already done as part of the next task:
-      - run: mix coveralls.github
+      - run: mix coveralls.github --trace

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -177,8 +177,7 @@ defmodule TypeCheck do
       case unquote(check) do
         {:ok, bindings, altered_value} -> {:ok, altered_value}
         {:error, problem} ->
-          # Use apply to silence Dialyzer
-          exception = apply(TypeCheck.TypeError, :exception, [{problem, unquote(Macro.Env.location(__CALLER__))}])
+          exception = TypeCheck.TypeError.exception({problem, unquote(Macro.Env.location(__CALLER__))})
           {:error, exception}
       end
     end
@@ -282,8 +281,7 @@ defmodule TypeCheck do
         {:current_stacktrace, [_ , caller | _]} = Process.info(self(), :current_stacktrace)
         location = elem(caller, 3)
         location = update_in(location[:file], &to_string/1)
-        # Use apply to silence Dialyzer
-        exception = apply(TypeCheck.TypeError, :exception, [{problem, location}])
+        exception = TypeCheck.TypeError.exception({problem, location})
         {:error, exception}
     end
   end

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -262,7 +262,7 @@ defmodule TypeCheck do
       {:ok, 42}
       iex> {:error, type_error} = TypeCheck.dynamic_conforms(20, fourty_two)
       iex> type_error.message
-      "At lib/type_check.ex:279:
+      "At lib/type_check.ex:281:
           `20` is not the same value as `42`."
   """
   @spec dynamic_conforms(value, TypeCheck.Type.t()) ::
@@ -315,7 +315,7 @@ defmodule TypeCheck do
       iex> TypeCheck.dynamic_conforms!(42, fourty_two)
       42
       iex> TypeCheck.dynamic_conforms!(20, fourty_two)
-      ** (TypeCheck.TypeError) At lib/type_check.ex:279:
+      ** (TypeCheck.TypeError) At lib/type_check.ex:281:
           `20` is not the same value as `42`.
   """
   @spec dynamic_conforms!(value, TypeCheck.Type.t()) :: value | no_return()

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -177,7 +177,8 @@ defmodule TypeCheck do
       case unquote(check) do
         {:ok, bindings, altered_value} -> {:ok, altered_value}
         {:error, problem} ->
-          exception = TypeCheck.TypeError.exception({problem, unquote(Macro.Env.location(__CALLER__))})
+          # Use apply to silence Dialyzer
+          exception = apply(TypeCheck.TypeError, :exception, [{problem, unquote(Macro.Env.location(__CALLER__))}])
           {:error, exception}
       end
     end
@@ -281,7 +282,8 @@ defmodule TypeCheck do
         {:current_stacktrace, [_ , caller | _]} = Process.info(self(), :current_stacktrace)
         location = elem(caller, 3)
         location = update_in(location[:file], &to_string/1)
-        exception = TypeCheck.TypeError.exception({problem, location})
+        # Use apply to silence Dialyzer
+        exception = apply(TypeCheck.TypeError, :exception, [{problem, location}])
         {:error, exception}
     end
   end

--- a/lib/type_check.ex
+++ b/lib/type_check.ex
@@ -176,7 +176,9 @@ defmodule TypeCheck do
     res = quote generated: true, location: :keep do
       case unquote(check) do
         {:ok, bindings, altered_value} -> {:ok, altered_value}
-        {:error, problem} -> {:error, TypeCheck.TypeError.exception({problem, unquote(Macro.Env.location(__CALLER__))})}
+        {:error, problem} ->
+          exception = TypeCheck.TypeError.exception({problem, unquote(Macro.Env.location(__CALLER__))})
+          {:error, exception}
       end
     end
 
@@ -279,7 +281,8 @@ defmodule TypeCheck do
         {:current_stacktrace, [_ , caller | _]} = Process.info(self(), :current_stacktrace)
         location = elem(caller, 3)
         location = update_in(location[:file], &to_string/1)
-        {:error, TypeCheck.TypeError.exception({problem, location})}
+        exception = TypeCheck.TypeError.exception({problem, location})
+        {:error, exception}
     end
   end
 

--- a/lib/type_check/builtin/maybe_improper_list.ex
+++ b/lib/type_check/builtin/maybe_improper_list.ex
@@ -174,7 +174,7 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
     defimpl TypeCheck.Protocols.ToStreamData do
       def to_gen(s) do
         require Blocked
-        Blocked.by("https://github.com/whatyouhide/stream_data/issues/169", "StreamData.maybe_improper_list_of is incorrect") do
+        # Blocked.by("https://github.com/whatyouhide/stream_data/issues/169", "StreamData.maybe_improper_list_of is incorrect") do
           element_gen =  TypeCheck.Protocols.ToStreamData.to_gen(s.element_type)
           terminator_gen = TypeCheck.Protocols.ToStreamData.to_gen(s.terminator_type)
           gen = StreamData.maybe_improper_list_of(element_gen, terminator_gen)
@@ -185,11 +185,11 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
             end
           end)
 
-        else
-          element_gen =  TypeCheck.Protocols.ToStreamData.to_gen(s.element_type)
-          terminator_gen = TypeCheck.Protocols.ToStreamData.to_gen(s.terminator_type)
-          StreamData.maybe_improper_list_of(element_gen, terminator_gen)
-        end
+        # else
+        #   element_gen =  TypeCheck.Protocols.ToStreamData.to_gen(s.element_type)
+        #   terminator_gen = TypeCheck.Protocols.ToStreamData.to_gen(s.terminator_type)
+        #   StreamData.maybe_improper_list_of(element_gen, terminator_gen)
+        # end
       end
     end
   end

--- a/lib/type_check/internals/bootstrap.ex
+++ b/lib/type_check/internals/bootstrap.ex
@@ -8,6 +8,7 @@ case Code.ensure_compiled(TypeCheck.Builtin.Any) do
   {:module, _} ->
 
     TypeCheck.Internals.Bootstrap.Macros.recompile(TypeCheck.Type, "lib/type_check/type.ex")
+    TypeCheck.Internals.Bootstrap.Macros.recompile(TypeCheck.Spec, "lib/type_check/spec.ex")
     TypeCheck.Internals.Bootstrap.Macros.recompile(TypeCheck.Options, "lib/type_check/options.ex")
     TypeCheck.Internals.Bootstrap.Macros.recompile(TypeCheck.Builtin, "lib/type_check/builtin.ex")
 end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -1,5 +1,4 @@
 defmodule TypeCheck.Spec do
-  @dialyzer :no_opaque
 
   defstruct [
     :name,
@@ -7,6 +6,12 @@ defmodule TypeCheck.Spec do
     :return_type,
     :location
   ]
+
+  import TypeCheck.Internals.Bootstrap.Macros
+  if_recompiling? do
+    @type! t() :: %__MODULE__{name: String.t(), param_types: list(TypeCheck.Type.t()), return_type: TypeCheck.Type.t(), location: [] | list({:file, binary()} | {:line, non_neg_integer()})}
+    @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  end
 
   defp spec_fun_name(function, arity) do
     :"__TypeCheck spec for '#{function}/#{arity}'__"

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -9,8 +9,10 @@ defmodule TypeCheck.Spec do
 
   import TypeCheck.Internals.Bootstrap.Macros
   if_recompiling? do
-    @type! t() :: %__MODULE__{name: String.t(), param_types: list(TypeCheck.Type.t()), return_type: TypeCheck.Type.t(), location: [] | list({:file, binary()} | {:line, non_neg_integer()})}
-    @type! problem_tuple :: {t(), :no_match, %{}, any()}
+    use TypeCheck
+    @type! t() :: %__MODULE__{name: binary(), param_types: list(TypeCheck.Type.t()), return_type: TypeCheck.Type.t(), location: [] | list({:file, binary()} | {:line, non_neg_integer()})}
+    @type! problem_tuple :: {t(), :param_error, %{index: non_neg_integer(), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, any()}
+    | {t(), :return_error, %{arguments: list(term()), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, any()}
   end
 
   defp spec_fun_name(function, arity) do

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -1,4 +1,6 @@
 defmodule TypeCheck.Spec do
+  @dialyzer :no_opaque
+
   defstruct [
     :name,
     :param_types,

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -156,7 +156,7 @@ defmodule TypeCheck.Spec do
 
       Kernel.unquote(function_kind)(unquote(name)(unquote_splicing(clean_params)), do: unquote(body))
 
-      # The result is checed in a separate function
+      # The result is checked in a separate function
       # This ensures we can convince Dialyzer to skip it. c.f. #85
       @compile {:inline, [{unquote(return_spec_fun_name), unquote(arity + 1)}]}
       @dialyzer {:nowarn_function, [{unquote(return_spec_fun_name), unquote(arity + 1)}]}

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -10,9 +10,10 @@ defmodule TypeCheck.Spec do
   import TypeCheck.Internals.Bootstrap.Macros
   if_recompiling? do
     use TypeCheck
-    @type! t() :: %__MODULE__{name: binary(), param_types: list(TypeCheck.Type.t()), return_type: TypeCheck.Type.t(), location: [] | list({:file, binary()} | {:line, non_neg_integer()})}
-    @type! problem_tuple :: {t(), :param_error, %{index: non_neg_integer(), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, any()}
-    | {t(), :return_error, %{arguments: list(term()), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, any()}
+    alias TypeCheck.DefaultOverrides.String
+    @type! t() :: %__MODULE__{name: String.t(), param_types: list(TypeCheck.Type.t()), return_type: TypeCheck.Type.t(), location: [] | list({:file, String.t()} | {:line, non_neg_integer()})}
+    @type! problem_tuple :: {t(), :param_error, %{index: non_neg_integer(), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, list(any())}
+    | {t(), :return_error, %{arguments: list(term()), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, list(any())}
   end
 
   defp spec_fun_name(function, arity) do

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -53,6 +53,7 @@ defmodule TypeCheck.TypeError do
           {type_checked_against(), check_name(), extra_information(), problematic_value()}
 
   @impl true
+  # @spec exception({problem_tuple(), any()} | problem_tuple()) :: t()
   def exception({problem_tuple, location}) do
     message = TypeCheck.TypeError.DefaultFormatter.format(problem_tuple, location)
 
@@ -60,6 +61,11 @@ defmodule TypeCheck.TypeError do
   end
 
   def exception(problem_tuple) do
-    exception({problem_tuple, []})
+    case problem_tuple do
+      {_, _, _, _} ->
+        exception({problem_tuple, []})
+      other ->
+        raise "Cannot make a TypeCheck.TypeError exception from #{inspect(other)}"
+    end
   end
 end

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -53,7 +53,7 @@ defmodule TypeCheck.TypeError do
           {type_checked_against(), check_name(), extra_information(), problematic_value()}
 
   @impl true
-  # @spec exception({problem_tuple(), any()} | problem_tuple()) :: t()
+  @dialyzer {:nowarn_function, [exception: 1]}
   def exception({problem_tuple, location}) do
     message = TypeCheck.TypeError.DefaultFormatter.format(problem_tuple, location)
 
@@ -61,11 +61,6 @@ defmodule TypeCheck.TypeError do
   end
 
   def exception(problem_tuple) do
-    case problem_tuple do
-      {_, _, _, _} ->
-        exception({problem_tuple, []})
-      other ->
-        raise "Cannot make a TypeCheck.TypeError exception from #{inspect(other)}"
-    end
+    exception({problem_tuple, []})
   end
 end

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -54,8 +54,6 @@ defmodule TypeCheck.TypeError do
 
   @impl true
 
-  @dialyzer {:nowarn_function, [exception: 1]}
-  @dialyzer :no_opaque
   def exception({problem_tuple, location}) do
     message = TypeCheck.TypeError.DefaultFormatter.format(problem_tuple, location)
 

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -53,7 +53,7 @@ defmodule TypeCheck.TypeError do
           {type_checked_against(), check_name(), extra_information(), problematic_value()}
 
   @impl true
-  @dialyzer :nowarn_opaque
+  @dialyzer :no_opaque
   def exception({problem_tuple, location}) do
     message = TypeCheck.TypeError.DefaultFormatter.format(problem_tuple, location)
 

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -53,6 +53,9 @@ defmodule TypeCheck.TypeError do
           {type_checked_against(), check_name(), extra_information(), problematic_value()}
 
   @impl true
+
+  @dialyzer {:nowarn_function, [exception: 1]}
+  @dialyzer :no_opaque
   def exception({problem_tuple, location}) do
     message = TypeCheck.TypeError.DefaultFormatter.format(problem_tuple, location)
 

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -53,7 +53,6 @@ defmodule TypeCheck.TypeError do
           {type_checked_against(), check_name(), extra_information(), problematic_value()}
 
   @impl true
-  @dialyzer :no_opaque
   def exception({problem_tuple, location}) do
     message = TypeCheck.TypeError.DefaultFormatter.format(problem_tuple, location)
 

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -53,7 +53,7 @@ defmodule TypeCheck.TypeError do
           {type_checked_against(), check_name(), extra_information(), problematic_value()}
 
   @impl true
-  @dialyzer {:nowarn_function, [exception: 1]}
+  @dialyzer :nowarn_opaque
   def exception({problem_tuple, location}) do
     message = TypeCheck.TypeError.DefaultFormatter.format(problem_tuple, location)
 

--- a/lib/type_check/type_error/formatter.ex
+++ b/lib/type_check/type_error/formatter.ex
@@ -54,6 +54,7 @@ defmodule TypeCheck.TypeError.Formatter do
          | TypeCheck.Builtin.Reference.problem_tuple()
          | TypeCheck.Builtin.Range.problem_tuple()
          | TypeCheck.Builtin.Tuple.problem_tuple()
+         | TypeCheck.Spec.problem_tuple()
 
   @doc """
   A formatter is expected to turn a `problem_tuple` into a string

--- a/test/type_check/builtin_test.exs
+++ b/test/type_check/builtin_test.exs
@@ -142,7 +142,7 @@ defmodule TypeCheck.BuiltinTest do
         property "#{module}'s ToStreamData implementation conforms with its own type" do
           require TypeCheck.Type
           check all value <- TypeCheck.Protocols.ToStreamData.to_gen(TypeCheck.Type.build(unquote(type))) do
-            assert {:ok, _} = TypeCheck.conforms(value, unquote(type))
+            TypeCheck.conforms!(value, unquote(type))
           end
         end
       end


### PR DESCRIPTION
FIxes #95 