### PR TITLE
Improve compilation performance and reduce compiled module size

### DIFF
--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -1072,7 +1072,7 @@ defmodule TypeCheck.Builtin do
   if_recompiling? do
     # @spec! named_type(name :: atom() | String.t(), type :: TypeCheck.Type.t()) :: TypeCheck.Builtin.NamedType.t()
   end
-  def named_type(name, type, type_kind \\ :type) do
+  def named_type(name, type, type_kind \\ :type, called_as \\ nil) do
     TypeCheck.Type.ensure_type!(type)
 
     build_struct(TypeCheck.Builtin.NamedType)
@@ -1080,6 +1080,7 @@ defmodule TypeCheck.Builtin do
     |> Map.put(:type, type)
     |> Map.put(:local, true)
     |> Map.put(:type_kind, type_kind)
+    |> Map.put(:called_as, called_as)
   end
 
   @doc typekind: :extension

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -88,6 +88,12 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
     end
   end
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      %{s | fixed: TypeCheck.Protocols.Escape.escape(s.fixed), flexible: TypeCheck.Protocols.Escape.escape(s.flexible)}
+    end
+  end
+
   if Code.ensure_loaded?(StreamData) do
     defimpl TypeCheck.Protocols.ToStreamData do
       def to_gen(s) do

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -37,7 +37,7 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
             {:ok, bindings1 ++ bindings2, Map.merge(fixed_part, flexible_part)}
             else
               {:error, {_, reason, info, _val}} ->
-                {:error, {unquote(Macro.escape(s)), reason, info, unquote(param)}}
+                {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), reason, info, unquote(param)}}
           end
         end
 
@@ -50,7 +50,7 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
           val when is_map(val) ->
             {:ok, [], val}
           other ->
-            {:error, {unquote(Macro.escape(s)), :not_a_map, %{}, other}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, other}}
         end
       end
     end

--- a/lib/type_check/builtin/fixed_list.ex
+++ b/lib/type_check/builtin/fixed_list.ex
@@ -82,6 +82,12 @@ defmodule TypeCheck.Builtin.FixedList do
     end
   end
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      update_in(s.element_types, &Enum.map(&1, fn val -> TypeCheck.Protocols.Escape.escape(val) end))
+    end
+  end
+
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(s, opts) do
       s.element_types

--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -20,6 +20,13 @@ defmodule TypeCheck.Builtin.FixedMap do
            | {t(), :value_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, map()}
 
+
+    defimpl TypeCheck.Protocols.Escape do
+      def escape(s) do
+               update_in(s.keypairs, &Enum.map(&1, fn {key, val} -> {key, TypeCheck.Protocols.Escape.escape(val)} end))
+      end
+    end
+
   defimpl TypeCheck.Protocols.ToCheck do
     # Optimization: If we have no expectations on keys -> value types, remove those useless checks.
     def to_check(s = %TypeCheck.Builtin.FixedMap{keypairs: keypairs}, param)

--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -76,7 +76,7 @@ defmodule TypeCheck.Builtin.FixedMap do
 
           missing_keys ->
             {:error,
-             {unquote(Macro.escape(s)), :missing_keys, %{keys: missing_keys}, unquote(param)}}
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :missing_keys, %{keys: missing_keys}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -55,7 +55,7 @@ defmodule TypeCheck.Builtin.FixedMap do
           val when is_map(val) ->
             {:ok, [], val}
             other ->
-            {:error, {unquote(Macro.escape(s)), :not_a_map, %{}, other}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, other}}
         end
       end
     end
@@ -96,7 +96,7 @@ defmodule TypeCheck.Builtin.FixedMap do
 
           superfluous_keys ->
             {:error,
-             {unquote(Macro.escape(s)), :superfluous_keys, %{keys: superfluous_keys},
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :superfluous_keys, %{keys: superfluous_keys},
               unquote(param)}}
         end
       end
@@ -133,7 +133,7 @@ defmodule TypeCheck.Builtin.FixedMap do
         else
           {{:error, error}, key} ->
             {:error,
-             {unquote(Macro.escape(s)), :value_error, %{problem: error, key: key}, unquote(param)}}
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :value_error, %{problem: error, key: key}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/fixed_tuple.ex
+++ b/lib/type_check/builtin/fixed_tuple.ex
@@ -29,7 +29,7 @@ defmodule TypeCheck.Builtin.FixedTuple do
 
           x when tuple_size(x) != unquote(expected_size) ->
             {:error,
-             {unquote(Macro.escape(s)), :different_size, %{expected_size: unquote(expected_size)},
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :different_size, %{expected_size: unquote(expected_size)},
               x}}
 
           _ ->

--- a/lib/type_check/builtin/fixed_tuple.ex
+++ b/lib/type_check/builtin/fixed_tuple.ex
@@ -11,6 +11,12 @@ defmodule TypeCheck.Builtin.FixedTuple do
             %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), index: integer()},
             tuple()}
 
+    defimpl TypeCheck.Protocols.Escape do
+      def escape(s) do
+             update_in(s.element_types, &Enum.map(&1, fn val -> TypeCheck.Protocols.Escape.escape(val) end))
+      end
+    end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s = %{element_types: types_list}, param) do
       element_checks_ast = build_element_checks_ast(types_list, param, s)

--- a/lib/type_check/builtin/function.ex
+++ b/lib/type_check/builtin/function.ex
@@ -1,20 +1,22 @@
 defmodule TypeCheck.Builtin.Function do
-  defstruct [param_types: nil, return_type: %TypeCheck.Builtin.Any{}]
+  defstruct param_types: nil, return_type: %TypeCheck.Builtin.Any{}
 
   use TypeCheck
-  @opaque! t :: %TypeCheck.Builtin.Function{
-    param_types: list(TypeCheck.Type.t()) | nil,
-    return_type: TypeCheck.Type.t()
-  }
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
 
+  @opaque! t :: %TypeCheck.Builtin.Function{
+             param_types: list(TypeCheck.Type.t()) | nil,
+             return_type: TypeCheck.Type.t()
+           }
+  @type! problem_tuple :: {t(), :no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.Escape do
     def escape(s) do
-      # update_in(s.element_types, &Enum.map(&1, fn val -> escape(val) end))
-      require Logger
-      Logger.warn("Todo: escaping functions")
-      s # TODO!
+      s
+      |> Map.update!(:param_types, fn
+        nil -> nil
+        list when is_list(list) -> Enum.map(list, &TypeCheck.Protocols.Escape.escape(&1))
+      end)
+      |> Map.update!(:return_type, &TypeCheck.Protocols.Escape.escape(&1))
     end
   end
 
@@ -22,10 +24,12 @@ defmodule TypeCheck.Builtin.Function do
     def to_check(s, param) do
       quote generated: true, location: :keep do
         p = unquote(param)
+
         case p do
           unquote(is_function_check(s)) ->
             wrapped_fun = unquote(@for.contravariant_wrapper(s, param))
             {:ok, [], wrapped_fun}
+
           _ ->
             {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
         end
@@ -38,6 +42,7 @@ defmodule TypeCheck.Builtin.Function do
           quote generated: true, location: :keep do
             x when is_function(x)
           end
+
         list ->
           quote generated: true, location: :keep do
             x when is_function(x, unquote(length(list)))
@@ -50,50 +55,70 @@ defmodule TypeCheck.Builtin.Function do
     case s do
       %{param_types: nil, return_type: %TypeCheck.Builtin.Any{}} ->
         original
+
       %{param_types: [], return_type: %TypeCheck.Builtin.Any{}} ->
         original
+
       %{param_types: nil, return_type: return_type} ->
-        quote generated: true, location: :keep, bind_quoted: [fun: original, s: Macro.escape(s), return_type: Macro.escape(return_type)] do
+        quote generated: true,
+              location: :keep,
+              bind_quoted: [
+                fun: original,
+                s: Macro.escape(s),
+                return_type: Macro.escape(return_type)
+              ] do
           {:arity, arity} = Function.info(fun, :arity)
           clean_params = Macro.generate_arguments(arity, __MODULE__)
-          return_code_check = TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
+
+          return_code_check =
+            TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
 
           wrapper_ast =
             quote do
               fn unquote_splicing(clean_params) ->
                 var!(result, nil) = var!(fun).(unquote_splicing(clean_params))
+
                 case unquote(return_code_check) do
                   {:ok, _bindings, altered_return_value} ->
                     altered_return_value
+
                   {:error, problem} ->
                     raise TypeCheck.TypeError,
-                    {unquote(Macro.escape(s)), :return_error,
-                    %{problem: problem, arguments: unquote(clean_params)}, var!(result, nil)}
+                          {unquote(Macro.escape(s)), :return_error,
+                           %{problem: problem, arguments: unquote(clean_params)},
+                           var!(result, nil)}
                 end
               end
             end
+
           {fun, _} = Code.eval_quoted(wrapper_ast, [fun: fun], __ENV__)
 
           fun
         end
+
       %{param_types: [], return_type: return_type} ->
-        return_code_check = TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
+        return_code_check =
+          TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
 
         quote generated: true, location: :keep do
           fn ->
             var!(result, nil) = unquote(original).()
+
             case unquote(return_code_check) do
               {:ok, _bindings, altered_return_value} ->
                 altered_return_value
+
               {:error, problem} ->
                 raise TypeCheck.TypeError,
-                  {unquote(Macro.escape(s)), :return_error,
-                  %{problem: problem, arguments: []}, var!(result, nil)}
+                      {unquote(Macro.escape(s)), :return_error,
+                       %{problem: problem, arguments: []}, var!(result, nil)}
             end
           end
         end
+
       %{param_types: param_types, return_type: return_type} ->
         clean_params = Macro.generate_arguments(length(param_types), __MODULE__)
+
         param_checks =
           param_types
           |> Enum.zip(clean_params)
@@ -102,7 +127,8 @@ defmodule TypeCheck.Builtin.Function do
             param_check_code(param_type, clean_param, index)
           end)
 
-        return_code_check = TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
+        return_code_check =
+          TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
 
         quote do
           fn unquote_splicing(clean_params) ->
@@ -112,17 +138,20 @@ defmodule TypeCheck.Builtin.Function do
               case unquote(return_code_check) do
                 {:ok, _bindings, altered_return_value} ->
                   altered_return_value
+
                 {:error, problem} ->
                   raise TypeCheck.TypeError,
-                    {unquote(Macro.escape(s)), :return_error,
-                     %{problem: problem, arguments: unquote(clean_params)}, var!(result, nil)}
+                        {unquote(Macro.escape(s)), :return_error,
+                         %{problem: problem, arguments: unquote(clean_params)}, var!(result, nil)}
               end
             else
               {{:error, problem}, index, param_type} ->
                 raise TypeCheck.TypeError,
-                {
-                  {unquote(Macro.escape(s)), :param_error,
-                   %{index: index, problem: problem}, unquote(clean_params)}, []}
+                      {
+                        {unquote(Macro.escape(s)), :param_error,
+                         %{index: index, problem: problem}, unquote(clean_params)},
+                        []
+                      }
             end
           end
         end
@@ -131,9 +160,11 @@ defmodule TypeCheck.Builtin.Function do
 
   def param_check_code(param_type, clean_param, index) do
     impl = TypeCheck.Protocols.ToCheck.to_check(param_type, clean_param)
+
     quote generated: true, location: :keep do
       [
-        {{:ok, _bindings, altered_param}, _index, _param_type} <- {unquote(impl), unquote(index), unquote(Macro.escape(param_type))},
+        {{:ok, _bindings, altered_param}, _index, _param_type} <-
+          {unquote(impl), unquote(index), unquote(Macro.escape(param_type))},
         clean_param = altered_param
       ]
     end
@@ -145,6 +176,7 @@ defmodule TypeCheck.Builtin.Function do
         %{param_types: nil, return_type: %TypeCheck.Builtin.Any{}} ->
           "function()"
           |> Inspect.Algebra.color(:builtin_type, opts)
+
         %{param_types: nil, return_type: return_type} ->
           inspected_return_type = TypeCheck.Protocols.Inspect.inspect(return_type, opts)
 
@@ -153,6 +185,7 @@ defmodule TypeCheck.Builtin.Function do
           |> Inspect.Algebra.glue(Inspect.Algebra.color("->", :builtin_type, opts))
           |> Inspect.Algebra.glue(inspected_return_type)
           |> Inspect.Algebra.concat(Inspect.Algebra.color(")", :builtin_type, opts))
+
         %{param_types: types, return_type: return_type} ->
           inspected_param_types =
             types
@@ -182,6 +215,7 @@ defmodule TypeCheck.Builtin.Function do
             |> StreamData.bind(fn {arity, seed} ->
               create_wrapper(result_type, arity, seed)
             end)
+
           %{param_types: param_types, return_type: result_type} when is_list(param_types) ->
             arity = length(param_types)
 
@@ -194,18 +228,20 @@ defmodule TypeCheck.Builtin.Function do
 
       defp create_wrapper(result_type, arity, hash_seed) do
         clean_params = Macro.generate_arguments(arity, __MODULE__)
+
         wrapper_ast =
           quote do
-          fn unquote_splicing(clean_params) ->
-            persistent_seed = :erlang.phash2(unquote(clean_params), unquote(hash_seed))
+            fn unquote_splicing(clean_params) ->
+              persistent_seed = :erlang.phash2(unquote(clean_params), unquote(hash_seed))
 
-            unquote(Macro.escape(result_type))
-            |> TypeCheck.Protocols.ToStreamData.to_gen()
-            |> StreamData.seeded(persistent_seed)
-            |> Enum.take(1)
-            |> List.first
+              unquote(Macro.escape(result_type))
+              |> TypeCheck.Protocols.ToStreamData.to_gen()
+              |> StreamData.seeded(persistent_seed)
+              |> Enum.take(1)
+              |> List.first()
+            end
           end
-        end
+
         {fun, _} = Code.eval_quoted(wrapper_ast)
         StreamData.constant(fun)
       end

--- a/lib/type_check/builtin/function.ex
+++ b/lib/type_check/builtin/function.ex
@@ -8,6 +8,16 @@ defmodule TypeCheck.Builtin.Function do
   }
   @type! problem_tuple :: {t(), :no_match, %{}, any()}
 
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      # update_in(s.element_types, &Enum.map(&1, fn val -> escape(val) end))
+      require Logger
+      Logger.warn("Todo: escaping functions")
+      s # TODO!
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
       quote generated: true, location: :keep do

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -10,6 +10,13 @@ defmodule TypeCheck.Builtin.Guarded do
 
   @type! t() :: %TypeCheck.Builtin.Guarded{type: TypeCheck.Type.t(), guard: ast()}
 
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      update_in(s.type, &TypeCheck.Protocols.Escape.escape(&1))
+    end
+  end
+
   @doc false
   def extract_names(type) do
     case type do

--- a/lib/type_check/builtin/list.ex
+++ b/lib/type_check/builtin/list.ex
@@ -13,6 +13,12 @@ defmodule TypeCheck.Builtin.List do
               index: non_neg_integer()
             }, any()}
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+             update_in(s.element_type, &TypeCheck.Protocols.Escape.escape(&1))
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s = %{element_type: element_type}, param) do
       quote generated: true, location: :keep do

--- a/lib/type_check/builtin/list.ex
+++ b/lib/type_check/builtin/list.ex
@@ -24,7 +24,7 @@ defmodule TypeCheck.Builtin.List do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_list(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_a_list, %{}, unquote(param)}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_list, %{}, unquote(param)}}
 
           _ ->
             unquote(build_element_check(element_type, param, s))
@@ -58,7 +58,7 @@ defmodule TypeCheck.Builtin.List do
               {:error, problem} ->
                 problem =
                   {:error,
-                  {unquote(Macro.escape(s)), :element_error, %{problem: problem, index: index},
+                  {unquote(TypeCheck.Internals.Escaper.escape(s)), :element_error, %{problem: problem, index: index},
                     orig_param}}
 
                 {:halt, problem}

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -11,6 +11,12 @@ defmodule TypeCheck.Builtin.Map do
            | {t(), :value_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, any()}
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+               %{s | key_type: TypeCheck.Protocols.Escape.escape(s.key_type), value_type: TypeCheck.Protocols.Escape.escape(s.value_type)}
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
       quote generated: true, location: :keep do

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -22,7 +22,7 @@ defmodule TypeCheck.Builtin.Map do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_map(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_a_map, %{}, unquote(param)}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, unquote(param)}}
 
           _ ->
             unquote(build_keypairs_check(s.key_type, s.value_type, param, s))
@@ -64,7 +64,7 @@ defmodule TypeCheck.Builtin.Map do
               {{:error, problem}, _} ->
                 res =
                   {:error,
-                   {unquote(Macro.escape(s)), :key_error, %{problem: problem, key: key},
+                   {unquote(TypeCheck.Internals.Escaper.escape(s)), :key_error, %{problem: problem, key: key},
                     orig_param}}
 
                 {:halt, res}
@@ -72,7 +72,7 @@ defmodule TypeCheck.Builtin.Map do
               {_, {:error, problem}} ->
                 res =
                   {:error,
-                   {unquote(Macro.escape(s)), :value_error, %{problem: problem, key: key},
+                   {unquote(TypeCheck.Internals.Escaper.escape(s)), :value_error, %{problem: problem, key: key},
                     orig_param}}
 
                 {:halt, res}

--- a/lib/type_check/builtin/maybe_improper_list.ex
+++ b/lib/type_check/builtin/maybe_improper_list.ex
@@ -8,6 +8,7 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
            terminator_type: terminator_type
          }
 
+
   @type! problem_tuple ::
            {t(), :not_a_list, %{}, any()}
            | {t(), :element_error,
@@ -17,6 +18,12 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
               }, any()}
            | {t(), :terminator_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, any()}
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+               %{s | element_type: TypeCheck.Protocols.Escape.escape(s.element_type), terminator_type: TypeCheck.Protocols.Escape.escape(s.terminator_type)}
+    end
+  end
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -1,8 +1,8 @@
 defmodule TypeCheck.Builtin.NamedType do
-  defstruct [:name, :type, :local, :type_kind]
+  defstruct [:name, :type, :local, :type_kind, :called_as]
 
   use TypeCheck
-  @type! t :: %TypeCheck.Builtin.NamedType{name: atom(), type: TypeCheck.Type.t(), local: boolean(), type_kind: :type | :typep | :opaque}
+  @type! t :: %TypeCheck.Builtin.NamedType{name: atom(), type: TypeCheck.Type.t(), local: boolean(), type_kind: :type | :typep | :opaque, called_as: nil | {atom(), list(any())}}
 
   @type! problem_tuple ::
          {t(), :named_type, %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())},

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -32,7 +32,7 @@ defmodule TypeCheck.Builtin.OneOf do
 
         with unquote_splicing(snippets) do
           {:error,
-           {unquote(Macro.escape(x)), :all_failed, %{problems: Enum.reverse(problems)},
+           {unquote(TypeCheck.Internals.Escaper.escape(x)), :all_failed, %{problems: Enum.reverse(problems)},
             unquote(param)}}
         else
           {:ok, bindings, altered_param} ->

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -5,6 +5,13 @@ defmodule TypeCheck.Builtin.OneOf do
   @type! t() :: %TypeCheck.Builtin.OneOf{choices: list(TypeCheck.Type.t())}
   @type! problem_tuple :: {t(), :all_failed, %{problems: list(lazy(TypeCheck.TypeError.Formatter.problem_tuple))}, term()}
 
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      update_in(s.choices, &Enum.map(&1, fn type -> TypeCheck.Protocols.Escape.escape(type) end))
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(x = %{choices: choices}, param) do
       snippets =

--- a/lib/type_check/internals/escaper.ex
+++ b/lib/type_check/internals/escaper.ex
@@ -5,28 +5,44 @@ defmodule TypeCheck.Internals.Escaper do
   # to make sure that this compiled code is not ridiculously large
   # (c.f. #110)
 
-  def escape(s = %TypeCheck.Builtin.NamedType{}) do
-    case s do
-      %{called_as: {module, function, args}, type_kind: kind} when kind in [:type, :opaque] ->
-        quote do
-          unquote(module).unquote(function)(unquote_splicing(args))
-        end
-      other -> Macro.escape(other)
-    end
+  def escape(val) do
+    val
+    |> TypeCheck.Protocols.Escape.escape()
+    |> Macro.escape(unquote: :true)
   end
 
-  def escape(other_struct_or_map = %{}) do
-    Enum.map(other_struct_or_map, fn {key, value} ->
-      {key, escape(value)}
-    end)
-    |> Enum.into(%{})
-  end
+  # def escape(val) do
+  #   case do_escape(val) do
+  #     map = %{} ->
+  #       Macro.escape(map, unquote: true)
+  #     other ->
+  #       other
+  #   end
+  # end
 
-  def escape(list) when is_list(list) do
-    Enum.map(list, fn value -> escape(value) end)
-  end
+  # def do_escape(s = %TypeCheck.Builtin.NamedType{}) do
+  #   case s do
+  #     %{called_as: {module, function, args}, type_kind: kind} when kind in [:type, :opaque] ->
+  #       escaped_args = args
+  #       |> do_escape()
+  #       |> Macro.escape()
 
-  def escape(other) do
-    Macro.escape(other)
-  end
+  #       quote do
+  #         unquote(module).unquote(function)(unquote_splicing(escaped_args))
+  #       end
+  #     other -> other
+  #   end
+  # end
+
+  # def do_escape(other_struct_or_map = %{}) do
+  #   :maps.map(fn _key, value -> do_escape(value) end, other_struct_or_map)
+  # end
+
+  # def do_escape(list) when is_list(list) do
+  #   Enum.map(list, fn value -> do_escape(value) end)
+  # end
+
+  # def do_escape(other) do
+  #   other
+  # end
 end

--- a/lib/type_check/internals/escaper.ex
+++ b/lib/type_check/internals/escaper.ex
@@ -10,39 +10,4 @@ defmodule TypeCheck.Internals.Escaper do
     |> TypeCheck.Protocols.Escape.escape()
     |> Macro.escape(unquote: :true)
   end
-
-  # def escape(val) do
-  #   case do_escape(val) do
-  #     map = %{} ->
-  #       Macro.escape(map, unquote: true)
-  #     other ->
-  #       other
-  #   end
-  # end
-
-  # def do_escape(s = %TypeCheck.Builtin.NamedType{}) do
-  #   case s do
-  #     %{called_as: {module, function, args}, type_kind: kind} when kind in [:type, :opaque] ->
-  #       escaped_args = args
-  #       |> do_escape()
-  #       |> Macro.escape()
-
-  #       quote do
-  #         unquote(module).unquote(function)(unquote_splicing(escaped_args))
-  #       end
-  #     other -> other
-  #   end
-  # end
-
-  # def do_escape(other_struct_or_map = %{}) do
-  #   :maps.map(fn _key, value -> do_escape(value) end, other_struct_or_map)
-  # end
-
-  # def do_escape(list) when is_list(list) do
-  #   Enum.map(list, fn value -> do_escape(value) end)
-  # end
-
-  # def do_escape(other) do
-  #   other
-  # end
 end

--- a/lib/type_check/internals/escaper.ex
+++ b/lib/type_check/internals/escaper.ex
@@ -1,0 +1,32 @@
+defmodule TypeCheck.Internals.Escaper do
+  @moduledoc false
+  # Abbreviate types when inlining their literal structs
+  # in compiled code
+  # to make sure that this compiled code is not ridiculously large
+  # (c.f. #110)
+
+  def escape(s = %TypeCheck.Builtin.NamedType{}) do
+    case s do
+      %{called_as: {module, function, args}, type_kind: kind} when kind in [:type, :opaque] ->
+        quote do
+          unquote(module).unquote(function)(unquote_splicing(args))
+        end
+      other -> Macro.escape(other)
+    end
+  end
+
+  def escape(other_struct_or_map = %{}) do
+    Enum.map(other_struct_or_map, fn {key, value} ->
+      {key, escape(value)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  def escape(list) when is_list(list) do
+    Enum.map(list, fn value -> escape(value) end)
+  end
+
+  def escape(other) do
+    Macro.escape(other)
+  end
+end

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -575,8 +575,8 @@ defmodule TypeCheck.Macros do
 
   defp type_fun_definition(name_with_params, type, module_name, overrides, kind) do
     {name, params} = Macro.decompose_call(name_with_params)
-    IO.inspect(name, label: :name)
-    IO.inspect(params, label: :params)
+    # IO.inspect(name, label: :name)
+    # IO.inspect(params, label: :params)
 
     params_check_code =
       params

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -575,9 +575,6 @@ defmodule TypeCheck.Macros do
 
   defp type_fun_definition(name_with_params, type, module_name, overrides, kind) do
     {name, params} = Macro.decompose_call(name_with_params)
-    # IO.inspect(name, label: :name)
-    # IO.inspect(params, label: :params)
-
     params_check_code =
       params
       |> Enum.map(fn param ->

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -574,7 +574,9 @@ defmodule TypeCheck.Macros do
   end
 
   defp type_fun_definition(name_with_params, type, module_name, overrides, kind) do
-    {_name, params} = Macro.decompose_call(name_with_params)
+    {name, params} = Macro.decompose_call(name_with_params)
+    IO.inspect(name, label: :name)
+    IO.inspect(params, label: :params)
 
     params_check_code =
       params
@@ -603,7 +605,8 @@ defmodule TypeCheck.Macros do
         unquote_splicing(params_check_code)
         # import TypeCheck.Builtin
         unquote(type_expansion_loop_prevention_code(name_with_params))
-        TypeCheck.Builtin.named_type(unquote(pretty_type_name), unquote(type), unquote(kind)) |> Map.put(:local, false)
+        mfa = {unquote(module_name), unquote(name), unquote(params)}
+        TypeCheck.Builtin.named_type(unquote(pretty_type_name), unquote(type), unquote(kind), mfa) |> Map.put(:local, false)
       end
     end
   end

--- a/lib/type_check/protocols/escape.ex
+++ b/lib/type_check/protocols/escape.ex
@@ -1,0 +1,19 @@
+defprotocol TypeCheck.Protocols.Escape do
+  @moduledoc false
+  # Escaping of structs.
+  # Instead of always using `Macro.escape`,
+  # Try to be slightly more clever to make sure compile-time AST
+  # does not become super large
+
+  @fallback_to_any true
+
+  @spec escape(TypeCheck.Type.t()) :: Macro.t()
+  def escape(val)
+
+end
+
+defimpl TypeCheck.Protocols.Escape, for: Any do
+  def escape(val) do
+    val
+  end
+end

--- a/lib/type_check/protocols/escape.ex
+++ b/lib/type_check/protocols/escape.ex
@@ -1,9 +1,7 @@
 defprotocol TypeCheck.Protocols.Escape do
   @moduledoc false
   # Escaping of structs.
-  # Instead of always using `Macro.escape`,
-  # Try to be slightly more clever to make sure compile-time AST
-  # does not become super large
+  # c.f. TypeCheck.Internals.Escaper for more info
 
   @fallback_to_any true
 

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -198,7 +198,7 @@ defmodule TypeCheck.Spec do
       with unquote_splicing(paired_params) do
         # Run actual code
       else
-        {{:error, problem}, index, param_type} ->
+        {{:error, problem}, index} ->
           raise TypeCheck.TypeError,
           {
             {__MODULE__.unquote(spec_fun_name(name, arity))(), :param_error,
@@ -213,7 +213,7 @@ defmodule TypeCheck.Spec do
     # {file, line} = location
     quote generated: true, location: :keep do
       [
-        {{:ok, _bindings, altered_param}, _index, _param_type} <- {unquote(impl), unquote(index), unquote(Macro.escape(param_type))},
+        {{:ok, _bindings, altered_param}, _index} <- {unquote(impl), unquote(index)},
         clean_param = altered_param
        ]
     end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -113,8 +113,8 @@ defmodule TypeCheck.Spec do
         # import TypeCheck.Builtin
         %TypeCheck.Spec{
           name: unquote(name),
-          param_types: unquote(Macro.escape(param_types)),
-          return_type: unquote(Macro.escape(return_type)),
+          param_types: unquote(TypeCheck.Internals.Escaper.escape(param_types)),
+          return_type: unquote(TypeCheck.Internals.Escaper.escape(return_type)),
           location: {unquote(file), unquote(line)}
         }
       end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -106,6 +106,7 @@ defmodule TypeCheck.Spec do
   @doc false
   def create_spec_def(name, arity, param_types, return_type, {file, line}) do
     spec_fun_name = spec_fun_name(name, arity)
+    escaped_param_types = Enum.map(param_types, &TypeCheck.Internals.Escaper.escape/1)
 
     quote generated: true, location: :keep do
       @doc false
@@ -113,7 +114,7 @@ defmodule TypeCheck.Spec do
         # import TypeCheck.Builtin
         %TypeCheck.Spec{
           name: unquote(name),
-          param_types: unquote(TypeCheck.Internals.Escaper.escape(param_types)),
+          param_types: unquote(escaped_param_types),
           return_type: unquote(TypeCheck.Internals.Escaper.escape(return_type)),
           location: {unquote(file), unquote(line)}
         }


### PR DESCRIPTION
Partial fix for #110.

- [x] Named types keep track of how they are originally called.
- [x] In most places, when compiled, a (non-local) named type will compile to a call to its function rather than to its full specification. This significantly reduces the amount of large structs that are compiled into a module that uses a named type.
- [x] A new internal protocol to make sure that this escaping of named types is done correctly also in nested types.

The example snippet now generates an intermediate Erlang core module of only ~190MB rather than ~312MB. 