### PR TITLE
Further improve compilation performance and reduce compiled module size

### DIFF
--- a/lib/type_check/builtin.ex
+++ b/lib/type_check/builtin.ex
@@ -1072,7 +1072,7 @@ defmodule TypeCheck.Builtin do
   if_recompiling? do
     # @spec! named_type(name :: atom() | String.t(), type :: TypeCheck.Type.t()) :: TypeCheck.Builtin.NamedType.t()
   end
-  def named_type(name, type, type_kind \\ :type) do
+  def named_type(name, type, type_kind \\ :type, called_as \\ nil) do
     TypeCheck.Type.ensure_type!(type)
 
     build_struct(TypeCheck.Builtin.NamedType)
@@ -1080,6 +1080,7 @@ defmodule TypeCheck.Builtin do
     |> Map.put(:type, type)
     |> Map.put(:local, true)
     |> Map.put(:type_kind, type_kind)
+    |> Map.put(:called_as, called_as)
   end
 
   @doc typekind: :extension

--- a/lib/type_check/builtin/atom.ex
+++ b/lib/type_check/builtin/atom.ex
@@ -9,7 +9,7 @@ defmodule TypeCheck.Builtin.Atom do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -19,7 +19,7 @@ defmodule TypeCheck.Builtin.Atom do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/binary.ex
+++ b/lib/type_check/builtin/binary.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.Binary do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Binary do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/bitstring.ex
+++ b/lib/type_check/builtin/bitstring.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.Bitstring do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Bitstring do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/boolean.ex
+++ b/lib/type_check/builtin/boolean.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.Boolean do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Boolean do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -12,12 +12,12 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
   @type! t :: %__MODULE__{fixed: TypeCheck.Builtin.FixedMap.t(), flexible: TypeCheck.Builtin.Map.t()}
 
   @type! problem_tuple ::
-  {t(), :not_a_map, %{}, any()}
-  | {t(), :missing_keys, %{keys: list(atom())}, map()}
-  | {t(), :superfluous_keys, %{keys: list(atom())}, map()}
-  | {t(), :value_error,
+  {:not_a_map, %{}, any()}
+  | {:missing_keys, %{keys: list(atom())}, map()}
+  | {:superfluous_keys, %{keys: list(atom())}, map()}
+  | {:value_error,
      %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, map()}
-  | {t(), :key_error,
+  | {:key_error,
      %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, map()}
 
   defimpl TypeCheck.Protocols.ToCheck do
@@ -36,21 +36,21 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
             do
             {:ok, bindings1 ++ bindings2, Map.merge(fixed_part, flexible_part)}
             else
-              {:error, {_, reason, info, _val}} ->
-                {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), reason, info, unquote(param)}}
+              {:error, {reason, info, _val}} ->
+                {:error, {reason, info, unquote(param)}}
           end
         end
 
       res
     end
 
-    defp map_check(param, s) do
+    defp map_check(param, _s) do
       quote generated: true, location: :keep do
         case unquote(param) do
           val when is_map(val) ->
             {:ok, [], val}
           other ->
-            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, other}}
+            {:error, {:not_a_map, %{}, other}}
         end
       end
     end

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -88,6 +88,12 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
     end
   end
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      %{s | fixed: TypeCheck.Protocols.Escape.escape(s.fixed), flexible: TypeCheck.Protocols.Escape.escape(s.flexible)}
+    end
+  end
+
   if Code.ensure_loaded?(StreamData) do
     defimpl TypeCheck.Protocols.ToStreamData do
       def to_gen(s) do

--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -37,7 +37,7 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
             {:ok, bindings1 ++ bindings2, Map.merge(fixed_part, flexible_part)}
             else
               {:error, {_, reason, info, _val}} ->
-                {:error, {unquote(Macro.escape(s)), reason, info, unquote(param)}}
+                {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), reason, info, unquote(param)}}
           end
         end
 
@@ -50,7 +50,7 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
           val when is_map(val) ->
             {:ok, [], val}
           other ->
-            {:error, {unquote(Macro.escape(s)), :not_a_map, %{}, other}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, other}}
         end
       end
     end

--- a/lib/type_check/builtin/fixed_list.ex
+++ b/lib/type_check/builtin/fixed_list.ex
@@ -14,9 +14,9 @@ defmodule TypeCheck.Builtin.FixedList do
   @type! t :: %__MODULE__{element_types: list(TypeCheck.Type.t())}
 
   @type! problem_tuple ::
-         {t(), :not_a_list, %{}, any()}
-         | {t(), :different_length, %{expected_length: non_neg_integer()}, list()}
-         | {t(), :element_error,
+         {:not_a_list, %{}, any()}
+         | {:different_length, %{expected_length: non_neg_integer()}, list()}
+         | {:element_error,
             %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), index: non_neg_integer()},
             list()}
 
@@ -28,11 +28,11 @@ defmodule TypeCheck.Builtin.FixedList do
       quote generated: :true, location: :keep do
         case unquote(param) do
           x when not is_list(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_a_list, %{}, x}}
+            {:error, {:not_a_list, %{}, x}}
 
           x when length(x) != unquote(expected_length) ->
             {:error,
-             {unquote(Macro.escape(s)), :different_length,
+             {:different_length,
               %{expected_length: unquote(expected_length)}, x}}
 
           _ ->
@@ -41,7 +41,7 @@ defmodule TypeCheck.Builtin.FixedList do
       end
     end
 
-    def build_element_checks_ast(element_types, param, s) do
+    def build_element_checks_ast(element_types, param, _s) do
       element_checks =
         element_types
         |> Enum.with_index()
@@ -75,7 +75,7 @@ defmodule TypeCheck.Builtin.FixedList do
         else
           {{:error, error}, index, _rest} ->
             {:error,
-             {unquote(Macro.escape(s)), :element_error, %{problem: error, index: index},
+             {:element_error, %{problem: error, index: index},
               unquote(param)}}
         end
       end

--- a/lib/type_check/builtin/fixed_list.ex
+++ b/lib/type_check/builtin/fixed_list.ex
@@ -82,6 +82,12 @@ defmodule TypeCheck.Builtin.FixedList do
     end
   end
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      update_in(s.element_types, &Enum.map(&1, fn val -> TypeCheck.Protocols.Escape.escape(val) end))
+    end
+  end
+
   defimpl TypeCheck.Protocols.Inspect do
     def inspect(s, opts) do
       s.element_types

--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -20,6 +20,13 @@ defmodule TypeCheck.Builtin.FixedMap do
            | {t(), :value_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, map()}
 
+
+    defimpl TypeCheck.Protocols.Escape do
+      def escape(s) do
+               update_in(s.keypairs, &Enum.map(&1, fn {key, val} -> {key, TypeCheck.Protocols.Escape.escape(val)} end))
+      end
+    end
+
   defimpl TypeCheck.Protocols.ToCheck do
     # Optimization: If we have no expectations on keys -> value types, remove those useless checks.
     def to_check(s = %TypeCheck.Builtin.FixedMap{keypairs: keypairs}, param)

--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -14,10 +14,10 @@ defmodule TypeCheck.Builtin.FixedMap do
   @type! t :: %__MODULE__{keypairs: list({term(), TypeCheck.Type.t()})}
 
   @type! problem_tuple ::
-           {t(), :not_a_map, %{}, any()}
-           | {t(), :missing_keys, %{keys: list(atom())}, map()}
-           | {t(), :superfluous_keys, %{keys: list(atom())}, map()}
-           | {t(), :value_error,
+           {:not_a_map, %{}, any()}
+           | {:missing_keys, %{keys: list(atom())}, map()}
+           | {:superfluous_keys, %{keys: list(atom())}, map()}
+           | {:value_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, map()}
 
 
@@ -55,7 +55,7 @@ defmodule TypeCheck.Builtin.FixedMap do
           val when is_map(val) ->
             {:ok, [], val}
             other ->
-            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, other}}
+            {:error, {:not_a_map, %{}, other}}
         end
       end
     end
@@ -76,7 +76,7 @@ defmodule TypeCheck.Builtin.FixedMap do
 
           missing_keys ->
             {:error,
-             {unquote(TypeCheck.Internals.Escaper.escape(s)), :missing_keys, %{keys: missing_keys}, unquote(param)}}
+             {:missing_keys, %{keys: missing_keys}, unquote(param)}}
         end
       end
     end
@@ -96,7 +96,7 @@ defmodule TypeCheck.Builtin.FixedMap do
 
           superfluous_keys ->
             {:error,
-             {unquote(TypeCheck.Internals.Escaper.escape(s)), :superfluous_keys, %{keys: superfluous_keys},
+             {:superfluous_keys, %{keys: superfluous_keys},
               unquote(param)}}
         end
       end
@@ -133,7 +133,7 @@ defmodule TypeCheck.Builtin.FixedMap do
         else
           {{:error, error}, key} ->
             {:error,
-             {unquote(TypeCheck.Internals.Escaper.escape(s)), :value_error, %{problem: error, key: key}, unquote(param)}}
+             {:value_error, %{problem: error, key: key}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -76,7 +76,7 @@ defmodule TypeCheck.Builtin.FixedMap do
 
           missing_keys ->
             {:error,
-             {unquote(Macro.escape(s)), :missing_keys, %{keys: missing_keys}, unquote(param)}}
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :missing_keys, %{keys: missing_keys}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/fixed_map.ex
+++ b/lib/type_check/builtin/fixed_map.ex
@@ -55,7 +55,7 @@ defmodule TypeCheck.Builtin.FixedMap do
           val when is_map(val) ->
             {:ok, [], val}
             other ->
-            {:error, {unquote(Macro.escape(s)), :not_a_map, %{}, other}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, other}}
         end
       end
     end
@@ -96,7 +96,7 @@ defmodule TypeCheck.Builtin.FixedMap do
 
           superfluous_keys ->
             {:error,
-             {unquote(Macro.escape(s)), :superfluous_keys, %{keys: superfluous_keys},
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :superfluous_keys, %{keys: superfluous_keys},
               unquote(param)}}
         end
       end
@@ -133,7 +133,7 @@ defmodule TypeCheck.Builtin.FixedMap do
         else
           {{:error, error}, key} ->
             {:error,
-             {unquote(Macro.escape(s)), :value_error, %{problem: error, key: key}, unquote(param)}}
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :value_error, %{problem: error, key: key}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/fixed_tuple.ex
+++ b/lib/type_check/builtin/fixed_tuple.ex
@@ -29,7 +29,7 @@ defmodule TypeCheck.Builtin.FixedTuple do
 
           x when tuple_size(x) != unquote(expected_size) ->
             {:error,
-             {unquote(Macro.escape(s)), :different_size, %{expected_size: unquote(expected_size)},
+             {unquote(TypeCheck.Internals.Escaper.escape(s)), :different_size, %{expected_size: unquote(expected_size)},
               x}}
 
           _ ->

--- a/lib/type_check/builtin/fixed_tuple.ex
+++ b/lib/type_check/builtin/fixed_tuple.ex
@@ -11,6 +11,12 @@ defmodule TypeCheck.Builtin.FixedTuple do
             %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), index: integer()},
             tuple()}
 
+    defimpl TypeCheck.Protocols.Escape do
+      def escape(s) do
+             update_in(s.element_types, &Enum.map(&1, fn val -> TypeCheck.Protocols.Escape.escape(val) end))
+      end
+    end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s = %{element_types: types_list}, param) do
       element_checks_ast = build_element_checks_ast(types_list, param, s)

--- a/lib/type_check/builtin/fixed_tuple.ex
+++ b/lib/type_check/builtin/fixed_tuple.ex
@@ -5,9 +5,9 @@ defmodule TypeCheck.Builtin.FixedTuple do
   @type! t :: %__MODULE__{element_types: list(TypeCheck.Type.t())}
 
   @type! problem_tuple ::
-         {t(), :not_a_tuple, %{}, any()}
-         | {t(), :different_size, %{expected_size: integer()}, tuple()}
-         | {t(), :element_error,
+         {:not_a_tuple, %{}, any()}
+         | {:different_size, %{expected_size: integer()}, tuple()}
+         | {:element_error,
             %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), index: integer()},
             tuple()}
 
@@ -25,11 +25,11 @@ defmodule TypeCheck.Builtin.FixedTuple do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_tuple(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_a_tuple, %{}, x}}
+            {:error, {:not_a_tuple, %{}, x}}
 
           x when tuple_size(x) != unquote(expected_size) ->
             {:error,
-             {unquote(TypeCheck.Internals.Escaper.escape(s)), :different_size, %{expected_size: unquote(expected_size)},
+             {:different_size, %{expected_size: unquote(expected_size)},
               x}}
 
           _ ->
@@ -69,7 +69,7 @@ defmodule TypeCheck.Builtin.FixedTuple do
         else
           {{:error, error}, index} ->
             {:error,
-             {unquote(Macro.escape(s)), :element_error, %{problem: error, index: index},
+             {:element_error, %{problem: error, index: index},
               unquote(param)}}
         end
       end

--- a/lib/type_check/builtin/float.ex
+++ b/lib/type_check/builtin/float.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.Float do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Float do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/function.ex
+++ b/lib/type_check/builtin/function.ex
@@ -1,20 +1,22 @@
 defmodule TypeCheck.Builtin.Function do
-  defstruct [param_types: nil, return_type: %TypeCheck.Builtin.Any{}]
+  defstruct param_types: nil, return_type: %TypeCheck.Builtin.Any{}
 
   use TypeCheck
-  @opaque! t :: %TypeCheck.Builtin.Function{
-    param_types: list(TypeCheck.Type.t()) | nil,
-    return_type: TypeCheck.Type.t()
-  }
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
 
+  @opaque! t :: %TypeCheck.Builtin.Function{
+             param_types: list(TypeCheck.Type.t()) | nil,
+             return_type: TypeCheck.Type.t()
+           }
+  @type! problem_tuple :: {t(), :no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.Escape do
     def escape(s) do
-      # update_in(s.element_types, &Enum.map(&1, fn val -> escape(val) end))
-      require Logger
-      Logger.warn("Todo: escaping functions")
-      s # TODO!
+      s
+      |> Map.update!(:param_types, fn
+        nil -> nil
+        list when is_list(list) -> Enum.map(list, &TypeCheck.Protocols.Escape.escape(&1))
+      end)
+      |> Map.update!(:return_type, &TypeCheck.Protocols.Escape.escape(&1))
     end
   end
 
@@ -22,10 +24,12 @@ defmodule TypeCheck.Builtin.Function do
     def to_check(s, param) do
       quote generated: true, location: :keep do
         p = unquote(param)
+
         case p do
           unquote(is_function_check(s)) ->
             wrapped_fun = unquote(@for.contravariant_wrapper(s, param))
             {:ok, [], wrapped_fun}
+
           _ ->
             {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
         end
@@ -38,6 +42,7 @@ defmodule TypeCheck.Builtin.Function do
           quote generated: true, location: :keep do
             x when is_function(x)
           end
+
         list ->
           quote generated: true, location: :keep do
             x when is_function(x, unquote(length(list)))
@@ -50,50 +55,70 @@ defmodule TypeCheck.Builtin.Function do
     case s do
       %{param_types: nil, return_type: %TypeCheck.Builtin.Any{}} ->
         original
+
       %{param_types: [], return_type: %TypeCheck.Builtin.Any{}} ->
         original
+
       %{param_types: nil, return_type: return_type} ->
-        quote generated: true, location: :keep, bind_quoted: [fun: original, s: Macro.escape(s), return_type: Macro.escape(return_type)] do
+        quote generated: true,
+              location: :keep,
+              bind_quoted: [
+                fun: original,
+                s: Macro.escape(s),
+                return_type: Macro.escape(return_type)
+              ] do
           {:arity, arity} = Function.info(fun, :arity)
           clean_params = Macro.generate_arguments(arity, __MODULE__)
-          return_code_check = TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
+
+          return_code_check =
+            TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
 
           wrapper_ast =
             quote do
               fn unquote_splicing(clean_params) ->
                 var!(result, nil) = var!(fun).(unquote_splicing(clean_params))
+
                 case unquote(return_code_check) do
                   {:ok, _bindings, altered_return_value} ->
                     altered_return_value
+
                   {:error, problem} ->
                     raise TypeCheck.TypeError,
-                    {unquote(Macro.escape(s)), :return_error,
-                    %{problem: problem, arguments: unquote(clean_params)}, var!(result, nil)}
+                          {unquote(Macro.escape(s)), :return_error,
+                           %{problem: problem, arguments: unquote(clean_params)},
+                           var!(result, nil)}
                 end
               end
             end
+
           {fun, _} = Code.eval_quoted(wrapper_ast, [fun: fun], __ENV__)
 
           fun
         end
+
       %{param_types: [], return_type: return_type} ->
-        return_code_check = TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
+        return_code_check =
+          TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
 
         quote generated: true, location: :keep do
           fn ->
             var!(result, nil) = unquote(original).()
+
             case unquote(return_code_check) do
               {:ok, _bindings, altered_return_value} ->
                 altered_return_value
+
               {:error, problem} ->
                 raise TypeCheck.TypeError,
-                  {unquote(Macro.escape(s)), :return_error,
-                  %{problem: problem, arguments: []}, var!(result, nil)}
+                      {unquote(Macro.escape(s)), :return_error,
+                       %{problem: problem, arguments: []}, var!(result, nil)}
             end
           end
         end
+
       %{param_types: param_types, return_type: return_type} ->
         clean_params = Macro.generate_arguments(length(param_types), __MODULE__)
+
         param_checks =
           param_types
           |> Enum.zip(clean_params)
@@ -102,7 +127,8 @@ defmodule TypeCheck.Builtin.Function do
             param_check_code(param_type, clean_param, index)
           end)
 
-        return_code_check = TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
+        return_code_check =
+          TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:result, nil))
 
         quote do
           fn unquote_splicing(clean_params) ->
@@ -112,17 +138,20 @@ defmodule TypeCheck.Builtin.Function do
               case unquote(return_code_check) do
                 {:ok, _bindings, altered_return_value} ->
                   altered_return_value
+
                 {:error, problem} ->
                   raise TypeCheck.TypeError,
-                    {unquote(Macro.escape(s)), :return_error,
-                     %{problem: problem, arguments: unquote(clean_params)}, var!(result, nil)}
+                        {unquote(Macro.escape(s)), :return_error,
+                         %{problem: problem, arguments: unquote(clean_params)}, var!(result, nil)}
               end
             else
               {{:error, problem}, index, param_type} ->
                 raise TypeCheck.TypeError,
-                {
-                  {unquote(Macro.escape(s)), :param_error,
-                   %{index: index, problem: problem}, unquote(clean_params)}, []}
+                      {
+                        {unquote(Macro.escape(s)), :param_error,
+                         %{index: index, problem: problem}, unquote(clean_params)},
+                        []
+                      }
             end
           end
         end
@@ -131,9 +160,11 @@ defmodule TypeCheck.Builtin.Function do
 
   def param_check_code(param_type, clean_param, index) do
     impl = TypeCheck.Protocols.ToCheck.to_check(param_type, clean_param)
+
     quote generated: true, location: :keep do
       [
-        {{:ok, _bindings, altered_param}, _index, _param_type} <- {unquote(impl), unquote(index), unquote(Macro.escape(param_type))},
+        {{:ok, _bindings, altered_param}, _index, _param_type} <-
+          {unquote(impl), unquote(index), unquote(Macro.escape(param_type))},
         clean_param = altered_param
       ]
     end
@@ -145,6 +176,7 @@ defmodule TypeCheck.Builtin.Function do
         %{param_types: nil, return_type: %TypeCheck.Builtin.Any{}} ->
           "function()"
           |> Inspect.Algebra.color(:builtin_type, opts)
+
         %{param_types: nil, return_type: return_type} ->
           inspected_return_type = TypeCheck.Protocols.Inspect.inspect(return_type, opts)
 
@@ -153,6 +185,7 @@ defmodule TypeCheck.Builtin.Function do
           |> Inspect.Algebra.glue(Inspect.Algebra.color("->", :builtin_type, opts))
           |> Inspect.Algebra.glue(inspected_return_type)
           |> Inspect.Algebra.concat(Inspect.Algebra.color(")", :builtin_type, opts))
+
         %{param_types: types, return_type: return_type} ->
           inspected_param_types =
             types
@@ -182,6 +215,7 @@ defmodule TypeCheck.Builtin.Function do
             |> StreamData.bind(fn {arity, seed} ->
               create_wrapper(result_type, arity, seed)
             end)
+
           %{param_types: param_types, return_type: result_type} when is_list(param_types) ->
             arity = length(param_types)
 
@@ -194,18 +228,20 @@ defmodule TypeCheck.Builtin.Function do
 
       defp create_wrapper(result_type, arity, hash_seed) do
         clean_params = Macro.generate_arguments(arity, __MODULE__)
+
         wrapper_ast =
           quote do
-          fn unquote_splicing(clean_params) ->
-            persistent_seed = :erlang.phash2(unquote(clean_params), unquote(hash_seed))
+            fn unquote_splicing(clean_params) ->
+              persistent_seed = :erlang.phash2(unquote(clean_params), unquote(hash_seed))
 
-            unquote(Macro.escape(result_type))
-            |> TypeCheck.Protocols.ToStreamData.to_gen()
-            |> StreamData.seeded(persistent_seed)
-            |> Enum.take(1)
-            |> List.first
+              unquote(Macro.escape(result_type))
+              |> TypeCheck.Protocols.ToStreamData.to_gen()
+              |> StreamData.seeded(persistent_seed)
+              |> Enum.take(1)
+              |> List.first()
+            end
           end
-        end
+
         {fun, _} = Code.eval_quoted(wrapper_ast)
         StreamData.constant(fun)
       end

--- a/lib/type_check/builtin/function.ex
+++ b/lib/type_check/builtin/function.ex
@@ -8,6 +8,16 @@ defmodule TypeCheck.Builtin.Function do
   }
   @type! problem_tuple :: {t(), :no_match, %{}, any()}
 
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      # update_in(s.element_types, &Enum.map(&1, fn val -> escape(val) end))
+      require Logger
+      Logger.warn("Todo: escaping functions")
+      s # TODO!
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
       quote generated: true, location: :keep do

--- a/lib/type_check/builtin/function.ex
+++ b/lib/type_check/builtin/function.ex
@@ -7,7 +7,7 @@ defmodule TypeCheck.Builtin.Function do
              param_types: list(TypeCheck.Type.t()) | nil,
              return_type: TypeCheck.Type.t()
            }
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.Escape do
     def escape(s) do
@@ -31,7 +31,7 @@ defmodule TypeCheck.Builtin.Function do
             {:ok, [], wrapped_fun}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end
@@ -84,7 +84,7 @@ defmodule TypeCheck.Builtin.Function do
 
                   {:error, problem} ->
                     raise TypeCheck.TypeError,
-                          {unquote(Macro.escape(s)), :return_error,
+                          {:return_error,
                            %{problem: problem, arguments: unquote(clean_params)},
                            var!(result, nil)}
                 end

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -10,6 +10,13 @@ defmodule TypeCheck.Builtin.Guarded do
 
   @type! t() :: %TypeCheck.Builtin.Guarded{type: TypeCheck.Type.t(), guard: ast()}
 
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      update_in(s.type, &TypeCheck.Protocols.Escape.escape(&1))
+    end
+  end
+
   @doc false
   def extract_names(type) do
     case type do

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -10,6 +10,8 @@ defmodule TypeCheck.Builtin.Guarded do
 
   @type! t() :: %TypeCheck.Builtin.Guarded{type: TypeCheck.Type.t(), guard: ast()}
 
+  # TODO problem_tuple type
+
 
   defimpl TypeCheck.Protocols.Escape do
     def escape(s) do

--- a/lib/type_check/builtin/guarded.ex
+++ b/lib/type_check/builtin/guarded.ex
@@ -95,13 +95,13 @@ defmodule TypeCheck.Builtin.Guarded do
               {:ok, bindings, altered_param}
             else
               {:error,
-               {unquote(Macro.escape(s)), :guard_failed, %{bindings: bindings_map},
+               {:guard_failed, %{bindings: bindings_map},
                 unquote(param)}}
             end
 
           {:error, problem} ->
             {:error,
-             {unquote(Macro.escape(s)), :type_failed, %{problem: problem}, unquote(param)}}
+             {:type_failed, %{problem: problem}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/implements_protocol.ex
+++ b/lib/type_check/builtin/implements_protocol.ex
@@ -9,7 +9,7 @@ defmodule TypeCheck.Builtin.ImplementsProtocol do
 
   use TypeCheck
   @type! t :: %__MODULE__{protocol: module()}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -17,7 +17,7 @@ defmodule TypeCheck.Builtin.ImplementsProtocol do
         x = unquote(param)
         case unquote(s.protocol).impl_for(x) do
           nil ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, x}}
+            {:error, {:no_match, %{}, x}}
           _ ->
           {:ok, [], x}
         end

--- a/lib/type_check/builtin/integer.ex
+++ b/lib/type_check/builtin/integer.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.Integer do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Integer do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/list.ex
+++ b/lib/type_check/builtin/list.ex
@@ -6,8 +6,8 @@ defmodule TypeCheck.Builtin.List do
   @type! t(element_type) :: %__MODULE__{element_type: element_type}
 
   @type! problem_tuple ::
-         {t(), :not_a_list, %{}, any()}
-         | {t(), :element_error,
+         {:not_a_list, %{}, any()}
+         | {:element_error,
             %{
               problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()),
               index: non_neg_integer()
@@ -24,7 +24,7 @@ defmodule TypeCheck.Builtin.List do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_list(x) ->
-            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_list, %{}, unquote(param)}}
+            {:error, {:not_a_list, %{}, unquote(param)}}
 
           _ ->
             unquote(build_element_check(element_type, param, s))
@@ -58,7 +58,7 @@ defmodule TypeCheck.Builtin.List do
               {:error, problem} ->
                 problem =
                   {:error,
-                  {unquote(TypeCheck.Internals.Escaper.escape(s)), :element_error, %{problem: problem, index: index},
+                  {:element_error, %{problem: problem, index: index},
                     orig_param}}
 
                 {:halt, problem}

--- a/lib/type_check/builtin/list.ex
+++ b/lib/type_check/builtin/list.ex
@@ -13,6 +13,12 @@ defmodule TypeCheck.Builtin.List do
               index: non_neg_integer()
             }, any()}
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+             update_in(s.element_type, &TypeCheck.Protocols.Escape.escape(&1))
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s = %{element_type: element_type}, param) do
       quote generated: true, location: :keep do

--- a/lib/type_check/builtin/list.ex
+++ b/lib/type_check/builtin/list.ex
@@ -24,7 +24,7 @@ defmodule TypeCheck.Builtin.List do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_list(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_a_list, %{}, unquote(param)}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_list, %{}, unquote(param)}}
 
           _ ->
             unquote(build_element_check(element_type, param, s))
@@ -58,7 +58,7 @@ defmodule TypeCheck.Builtin.List do
               {:error, problem} ->
                 problem =
                   {:error,
-                  {unquote(Macro.escape(s)), :element_error, %{problem: problem, index: index},
+                  {unquote(TypeCheck.Internals.Escaper.escape(s)), :element_error, %{problem: problem, index: index},
                     orig_param}}
 
                 {:halt, problem}

--- a/lib/type_check/builtin/literal.ex
+++ b/lib/type_check/builtin/literal.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.Literal do
 
   use TypeCheck
   @type! t :: %__MODULE__{value: term()}
-  @type! problem_tuple :: {t(), :not_same_value, %{}, value :: term()}
+  @type! problem_tuple :: {:not_same_value, %{}, value :: term()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s = %{value: value}, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Literal do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :not_same_value, %{}, unquote(param)}}
+            {:error, {:not_same_value, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -5,10 +5,10 @@ defmodule TypeCheck.Builtin.Map do
   @opaque! t :: %__MODULE__{key_type: TypeCheck.Type.t(), value_type: TypeCheck.Type.t()}
 
   @type! problem_tuple ::
-           {t(), :not_a_map, %{}, any()}
-           | {t(), :key_error,
+           {:not_a_map, %{}, any()}
+           | {:key_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, any()}
-           | {t(), :value_error,
+           | {:value_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, any()}
 
   defimpl TypeCheck.Protocols.Escape do
@@ -22,7 +22,7 @@ defmodule TypeCheck.Builtin.Map do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_map(x) ->
-            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, unquote(param)}}
+            {:error, {:not_a_map, %{}, unquote(param)}}
 
           _ ->
             unquote(build_keypairs_check(s.key_type, s.value_type, param, s))
@@ -64,7 +64,7 @@ defmodule TypeCheck.Builtin.Map do
               {{:error, problem}, _} ->
                 res =
                   {:error,
-                   {unquote(TypeCheck.Internals.Escaper.escape(s)), :key_error, %{problem: problem, key: key},
+                   {:key_error, %{problem: problem, key: key},
                     orig_param}}
 
                 {:halt, res}
@@ -72,7 +72,7 @@ defmodule TypeCheck.Builtin.Map do
               {_, {:error, problem}} ->
                 res =
                   {:error,
-                   {unquote(TypeCheck.Internals.Escaper.escape(s)), :value_error, %{problem: problem, key: key},
+                   {:value_error, %{problem: problem, key: key},
                     orig_param}}
 
                 {:halt, res}

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -11,6 +11,12 @@ defmodule TypeCheck.Builtin.Map do
            | {t(), :value_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()), key: any()}, any()}
 
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+               %{s | key_type: TypeCheck.Protocols.Escape.escape(s.key_type), value_type: TypeCheck.Protocols.Escape.escape(s.value_type)}
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
       quote generated: true, location: :keep do

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -22,7 +22,7 @@ defmodule TypeCheck.Builtin.Map do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_map(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_a_map, %{}, unquote(param)}}
+            {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :not_a_map, %{}, unquote(param)}}
 
           _ ->
             unquote(build_keypairs_check(s.key_type, s.value_type, param, s))
@@ -64,7 +64,7 @@ defmodule TypeCheck.Builtin.Map do
               {{:error, problem}, _} ->
                 res =
                   {:error,
-                   {unquote(Macro.escape(s)), :key_error, %{problem: problem, key: key},
+                   {unquote(TypeCheck.Internals.Escaper.escape(s)), :key_error, %{problem: problem, key: key},
                     orig_param}}
 
                 {:halt, res}
@@ -72,7 +72,7 @@ defmodule TypeCheck.Builtin.Map do
               {_, {:error, problem}} ->
                 res =
                   {:error,
-                   {unquote(Macro.escape(s)), :value_error, %{problem: problem, key: key},
+                   {unquote(TypeCheck.Internals.Escaper.escape(s)), :value_error, %{problem: problem, key: key},
                     orig_param}}
 
                 {:halt, res}

--- a/lib/type_check/builtin/maybe_improper_list.ex
+++ b/lib/type_check/builtin/maybe_improper_list.ex
@@ -8,6 +8,7 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
            terminator_type: terminator_type
          }
 
+
   @type! problem_tuple ::
            {t(), :not_a_list, %{}, any()}
            | {t(), :element_error,
@@ -17,6 +18,12 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
               }, any()}
            | {t(), :terminator_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, any()}
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+               %{s | element_type: TypeCheck.Protocols.Escape.escape(s.element_type), terminator_type: TypeCheck.Protocols.Escape.escape(s.terminator_type)}
+    end
+  end
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do

--- a/lib/type_check/builtin/maybe_improper_list.ex
+++ b/lib/type_check/builtin/maybe_improper_list.ex
@@ -10,13 +10,13 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
 
 
   @type! problem_tuple ::
-           {t(), :not_a_list, %{}, any()}
-           | {t(), :element_error,
+           {:not_a_list, %{}, any()}
+           | {:element_error,
               %{
                 problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple()),
                 index: non_neg_integer()
               }, any()}
-           | {t(), :terminator_error,
+           | {:terminator_error,
               %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, any()}
 
   defimpl TypeCheck.Protocols.Escape do
@@ -30,7 +30,7 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_list(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_a_list, %{}, unquote(param)}}
+            {:error, {:not_a_list, %{}, unquote(param)}}
 
           _ ->
             unquote(build_element_check(s, param))
@@ -70,7 +70,7 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
 
                 {:error, problem} ->
                   {:error,
-                   {unquote(Macro.escape(s)), :terminator_error, %{problem: problem, index: index},
+                   {:terminator_error, %{problem: problem, index: index},
                     orig_param}}
               end
             else
@@ -81,7 +81,7 @@ defmodule TypeCheck.Builtin.MaybeImproperList do
                 {:error, problem} ->
                   problem =
                     {:error,
-                     {unquote(Macro.escape(s)), :element_error, %{problem: problem, index: index},
+                     {:element_error, %{problem: problem, index: index},
                       orig_param}}
 
                   {:halt, problem}

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -45,7 +45,7 @@ defmodule TypeCheck.Builtin.NamedType do
               # Reset bindings
               {:ok, [], altered_inner}
             {:error, problem} ->
-              {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :named_type, %{problem: problem}, unquote(param)}}
+              {:error, {:named_type, %{problem: problem}, unquote(param)}}
           end
         end
       else
@@ -59,7 +59,7 @@ defmodule TypeCheck.Builtin.NamedType do
               {:ok, [{unquote(s.name), unquote(param)} | bindings], altered_inner}
 
             {:error, problem} ->
-              {:error, {unquote(TypeCheck.Internals.Escaper.escape(s)), :named_type, %{problem: problem}, unquote(param)}}
+              {:error, {:named_type, %{problem: problem}, unquote(param)}}
           end
         end
       end

--- a/lib/type_check/builtin/named_type.ex
+++ b/lib/type_check/builtin/named_type.ex
@@ -1,8 +1,8 @@
 defmodule TypeCheck.Builtin.NamedType do
-  defstruct [:name, :type, :local, :type_kind]
+  defstruct [:name, :type, :local, :type_kind, :called_as]
 
   use TypeCheck
-  @type! t :: %TypeCheck.Builtin.NamedType{name: atom(), type: TypeCheck.Type.t(), local: boolean(), type_kind: :type | :typep | :opaque}
+  @type! t :: %TypeCheck.Builtin.NamedType{name: atom(), type: TypeCheck.Type.t(), local: boolean(), type_kind: :type | :typep | :opaque, called_as: nil | {atom(), list(any())}}
 
   @type! problem_tuple ::
          {t(), :named_type, %{problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())},

--- a/lib/type_check/builtin/neg_integer.ex
+++ b/lib/type_check/builtin/neg_integer.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.NegInteger do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.NegInteger do
             {:ok, [], unquote(param)}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/non_neg_integer.ex
+++ b/lib/type_check/builtin/non_neg_integer.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.NonNegInteger do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.NonNegInteger do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/none.ex
+++ b/lib/type_check/builtin/none.ex
@@ -15,12 +15,12 @@ defmodule TypeCheck.Builtin.None do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, val :: any()}
+  @type! problem_tuple :: {:no_match, %{}, val :: any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
       quote generated: true, location: :keep do
-        {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+        {:error, {:no_match, %{}, unquote(param)}}
       end
     end
   end

--- a/lib/type_check/builtin/number.ex
+++ b/lib/type_check/builtin/number.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.Number do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, val :: any()}
+  @type! problem_tuple :: {:no_match, %{}, val :: any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Number do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.OneOf do
 
   use TypeCheck
   @type! t() :: %TypeCheck.Builtin.OneOf{choices: list(TypeCheck.Type.t())}
-  @type! problem_tuple :: {t(), :all_failed, %{problems: list(lazy(TypeCheck.TypeError.Formatter.problem_tuple))}, term()}
+  @type! problem_tuple :: {:all_failed, %{problems: list(lazy(TypeCheck.TypeError.Formatter.problem_tuple))}, term()}
 
 
   defimpl TypeCheck.Protocols.Escape do
@@ -32,7 +32,7 @@ defmodule TypeCheck.Builtin.OneOf do
 
         with unquote_splicing(snippets) do
           {:error,
-           {unquote(TypeCheck.Internals.Escaper.escape(x)), :all_failed, %{problems: Enum.reverse(problems)},
+           {:all_failed, %{problems: Enum.reverse(problems)},
             unquote(param)}}
         else
           {:ok, bindings, altered_param} ->

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -32,7 +32,7 @@ defmodule TypeCheck.Builtin.OneOf do
 
         with unquote_splicing(snippets) do
           {:error,
-           {unquote(Macro.escape(x)), :all_failed, %{problems: Enum.reverse(problems)},
+           {unquote(TypeCheck.Internals.Escaper.escape(x)), :all_failed, %{problems: Enum.reverse(problems)},
             unquote(param)}}
         else
           {:ok, bindings, altered_param} ->

--- a/lib/type_check/builtin/one_of.ex
+++ b/lib/type_check/builtin/one_of.ex
@@ -5,6 +5,13 @@ defmodule TypeCheck.Builtin.OneOf do
   @type! t() :: %TypeCheck.Builtin.OneOf{choices: list(TypeCheck.Type.t())}
   @type! problem_tuple :: {t(), :all_failed, %{problems: list(lazy(TypeCheck.TypeError.Formatter.problem_tuple))}, term()}
 
+
+  defimpl TypeCheck.Protocols.Escape do
+    def escape(s) do
+      update_in(s.choices, &Enum.map(&1, fn type -> TypeCheck.Protocols.Escape.escape(type) end))
+    end
+  end
+
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(x = %{choices: choices}, param) do
       snippets =

--- a/lib/type_check/builtin/pid.ex
+++ b/lib/type_check/builtin/pid.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.PID do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.PID do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/port.ex
+++ b/lib/type_check/builtin/port.ex
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.Port do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -22,7 +22,7 @@ defmodule TypeCheck.Builtin.Port do
           x when is_port(x) ->
             {:ok, [], x}
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/pos_integer.ex
+++ b/lib/type_check/builtin/pos_integer.ex
@@ -3,7 +3,7 @@ defmodule TypeCheck.Builtin.PosInteger do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -13,7 +13,7 @@ defmodule TypeCheck.Builtin.PosInteger do
             {:ok, [], x}
 
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/range.ex
+++ b/lib/type_check/builtin/range.ex
@@ -10,18 +10,18 @@ defmodule TypeCheck.Builtin.Range do
   end
 
   @type! problem_tuple ::
-         {t(), :not_an_integer, %{}, any()}
-         | {t(), :not_in_range, %{}, integer()}
+         {:not_an_integer, %{}, any()}
+         | {:not_in_range, %{}, integer()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s = %{range: range}, param) do
       quote generated: true, location: :keep do
         case unquote(param) do
           x when not is_integer(x) ->
-            {:error, {unquote(Macro.escape(s)), :not_an_integer, %{}, unquote(param)}}
+            {:error, {:not_an_integer, %{}, unquote(param)}}
 
           x when x not in unquote(Macro.escape(range)) ->
-            {:error, {unquote(Macro.escape(s)), :not_in_range, %{}, unquote(param)}}
+            {:error, {:not_in_range, %{}, unquote(param)}}
 
           correct_value ->
             {:ok, [], correct_value}

--- a/lib/type_check/builtin/reference.ex
+++ b/lib/type_check/builtin/reference.ex
@@ -14,7 +14,7 @@ defmodule TypeCheck.Builtin.Reference do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -23,7 +23,7 @@ defmodule TypeCheck.Builtin.Reference do
           x when is_reference(x) ->
             {:ok, [], x}
           _ ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+            {:error, {:no_match, %{}, unquote(param)}}
         end
       end
     end

--- a/lib/type_check/builtin/sized_bitstring.ex
+++ b/lib/type_check/builtin/sized_bitstring.ex
@@ -5,8 +5,8 @@ defmodule TypeCheck.Builtin.SizedBitstring do
 
   @type! t :: %__MODULE__{prefix_size: non_neg_integer(), unit_size: nil | 1..256}
   @type! problem_tuple ::
-    {t(), :no_match, %{}, any()}
-  | {t(), :wrong_size, %{}, any()}
+    {:no_match, %{}, any()}
+  | { :wrong_size, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -14,9 +14,9 @@ defmodule TypeCheck.Builtin.SizedBitstring do
         quote generated: true, location: :keep do
           case unquote(param) do
             x when not is_bitstring(x) ->
-              {:error, {unquote(Macro.escape(s)), :no_match, %{}, unquote(param)}}
+              {:error, {:no_match, %{}, unquote(param)}}
             x when bit_size(x) != unquote(s.prefix_size) ->
-              {:error, {unquote(Macro.escape(s)), :wrong_size, %{}, unquote(param)}}
+              {:error, {:wrong_size, %{}, unquote(param)}}
             _ ->
               {:ok, [], unquote(param)}
           end
@@ -25,9 +25,9 @@ defmodule TypeCheck.Builtin.SizedBitstring do
         quote generated: true, location: :keep do
           case unquote(param) do
             x when not is_bitstring(x) ->
-              {:error, {unquote(Macro.escape(s)), :no_match, %{}, x}}
+              {:error, {:no_match, %{}, x}}
             x when bit_size(x) < unquote(s.prefix_size) or rem(bit_size(x) - unquote(s.prefix_size), unquote(s.unit_size)) != 0 ->
-              {:error, {unquote(Macro.escape(s)), :wrong_size, %{}, x}}
+              {:error, {:wrong_size, %{}, x}}
             correct_value ->
               {:ok, [], correct_value}
           end

--- a/lib/type_check/builtin/tuple.ex
+++ b/lib/type_check/builtin/tuple.ex
@@ -9,7 +9,7 @@ defmodule TypeCheck.Builtin.Tuple do
 
   use TypeCheck
   @type! t :: %__MODULE__{}
-  @type! problem_tuple :: {t(), :no_match, %{}, any()}
+  @type! problem_tuple :: {:no_match, %{}, any()}
 
   defimpl TypeCheck.Protocols.ToCheck do
     def to_check(s, param) do
@@ -19,7 +19,7 @@ defmodule TypeCheck.Builtin.Tuple do
             {:ok, [], x}
 
           other ->
-            {:error, {unquote(Macro.escape(s)), :no_match, %{}, other}}
+            {:error, {:no_match, %{}, other}}
         end
       end
     end

--- a/lib/type_check/external.ex
+++ b/lib/type_check/external.ex
@@ -24,7 +24,7 @@ defmodule TypeCheck.External do
       iex> enforce_spec!(Kernel.abs(-13))
       13
       iex> enforce_spec!(Kernel.abs("hi"))
-      ** (TypeCheck.TypeError) At lib/type_check/external.ex:175:
+      ** (TypeCheck.TypeError) At lib/type_check/external.ex:176:
           `"hi"` is not a number.
   """
   @spec enforce_spec!(Macro.t()) :: Macro.t() | no_return
@@ -132,7 +132,7 @@ defmodule TypeCheck.External do
       iex> TypeCheck.External.apply!(type, Kernel, :abs, [-13])
       13
       iex> TypeCheck.External.apply!(type, Kernel, :abs, ["hello"])
-      ** (TypeCheck.TypeError) At lib/type_check/external.ex:175:
+      ** (TypeCheck.TypeError) At lib/type_check/external.ex:176:
           `"hello"` is not a number.
 
   """
@@ -156,7 +156,7 @@ defmodule TypeCheck.External do
       {:ok, 13}
       iex> {:error, err} = TypeCheck.External.apply(type, Kernel, :abs, [false])
       iex> err.message
-      "At lib/type_check/external.ex:175:\\n    `false` is not a number."
+      "At lib/type_check/external.ex:176:\\n    `false` is not a number."
 
   """
   @spec apply(TypeCheck.Type.t(), module(), atom(), list()) ::

--- a/lib/type_check/internals/escaper.ex
+++ b/lib/type_check/internals/escaper.ex
@@ -5,28 +5,44 @@ defmodule TypeCheck.Internals.Escaper do
   # to make sure that this compiled code is not ridiculously large
   # (c.f. #110)
 
-  def escape(s = %TypeCheck.Builtin.NamedType{}) do
-    case s do
-      %{called_as: {module, function, args}, type_kind: kind} when kind in [:type, :opaque] ->
-        quote do
-          unquote(module).unquote(function)(unquote_splicing(args))
-        end
-      other -> Macro.escape(other)
-    end
+  def escape(val) do
+    val
+    |> TypeCheck.Protocols.Escape.escape()
+    |> Macro.escape(unquote: :true)
   end
 
-  def escape(other_struct_or_map = %{}) do
-    Enum.map(other_struct_or_map, fn {key, value} ->
-      {key, escape(value)}
-    end)
-    |> Enum.into(%{})
-  end
+  # def escape(val) do
+  #   case do_escape(val) do
+  #     map = %{} ->
+  #       Macro.escape(map, unquote: true)
+  #     other ->
+  #       other
+  #   end
+  # end
 
-  def escape(list) when is_list(list) do
-    Enum.map(list, fn value -> escape(value) end)
-  end
+  # def do_escape(s = %TypeCheck.Builtin.NamedType{}) do
+  #   case s do
+  #     %{called_as: {module, function, args}, type_kind: kind} when kind in [:type, :opaque] ->
+  #       escaped_args = args
+  #       |> do_escape()
+  #       |> Macro.escape()
 
-  def escape(other) do
-    Macro.escape(other)
-  end
+  #       quote do
+  #         unquote(module).unquote(function)(unquote_splicing(escaped_args))
+  #       end
+  #     other -> other
+  #   end
+  # end
+
+  # def do_escape(other_struct_or_map = %{}) do
+  #   :maps.map(fn _key, value -> do_escape(value) end, other_struct_or_map)
+  # end
+
+  # def do_escape(list) when is_list(list) do
+  #   Enum.map(list, fn value -> do_escape(value) end)
+  # end
+
+  # def do_escape(other) do
+  #   other
+  # end
 end

--- a/lib/type_check/internals/escaper.ex
+++ b/lib/type_check/internals/escaper.ex
@@ -1,0 +1,32 @@
+defmodule TypeCheck.Internals.Escaper do
+  @moduledoc false
+  # Abbreviate types when inlining their literal structs
+  # in compiled code
+  # to make sure that this compiled code is not ridiculously large
+  # (c.f. #110)
+
+  def escape(s = %TypeCheck.Builtin.NamedType{}) do
+    case s do
+      %{called_as: {module, function, args}, type_kind: kind} when kind in [:type, :opaque] ->
+        quote do
+          unquote(module).unquote(function)(unquote_splicing(args))
+        end
+      other -> Macro.escape(other)
+    end
+  end
+
+  def escape(other_struct_or_map = %{}) do
+    Enum.map(other_struct_or_map, fn {key, value} ->
+      {key, escape(value)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  def escape(list) when is_list(list) do
+    Enum.map(list, fn value -> escape(value) end)
+  end
+
+  def escape(other) do
+    Macro.escape(other)
+  end
+end

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -575,8 +575,8 @@ defmodule TypeCheck.Macros do
 
   defp type_fun_definition(name_with_params, type, module_name, overrides, kind) do
     {name, params} = Macro.decompose_call(name_with_params)
-    IO.inspect(name, label: :name)
-    IO.inspect(params, label: :params)
+    # IO.inspect(name, label: :name)
+    # IO.inspect(params, label: :params)
 
     params_check_code =
       params

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -574,7 +574,9 @@ defmodule TypeCheck.Macros do
   end
 
   defp type_fun_definition(name_with_params, type, module_name, overrides, kind) do
-    {_name, params} = Macro.decompose_call(name_with_params)
+    {name, params} = Macro.decompose_call(name_with_params)
+    IO.inspect(name, label: :name)
+    IO.inspect(params, label: :params)
 
     params_check_code =
       params
@@ -603,7 +605,8 @@ defmodule TypeCheck.Macros do
         unquote_splicing(params_check_code)
         # import TypeCheck.Builtin
         unquote(type_expansion_loop_prevention_code(name_with_params))
-        TypeCheck.Builtin.named_type(unquote(pretty_type_name), unquote(type), unquote(kind)) |> Map.put(:local, false)
+        mfa = {unquote(module_name), unquote(name), unquote(params)}
+        TypeCheck.Builtin.named_type(unquote(pretty_type_name), unquote(type), unquote(kind), mfa) |> Map.put(:local, false)
       end
     end
   end

--- a/lib/type_check/protocols/escape.ex
+++ b/lib/type_check/protocols/escape.ex
@@ -1,0 +1,19 @@
+defprotocol TypeCheck.Protocols.Escape do
+  @moduledoc false
+  # Escaping of structs.
+  # Instead of always using `Macro.escape`,
+  # Try to be slightly more clever to make sure compile-time AST
+  # does not become super large
+
+  @fallback_to_any true
+
+  @spec escape(TypeCheck.Type.t()) :: Macro.t()
+  def escape(val)
+
+end
+
+defimpl TypeCheck.Protocols.Escape, for: Any do
+  def escape(val) do
+    val
+  end
+end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -202,8 +202,8 @@ defmodule TypeCheck.Spec do
         {{:error, problem}, index} ->
           raise TypeCheck.TypeError,
           {
-            {__MODULE__.unquote(spec_fun_name(name, arity))(), :param_error,
-             %{index: index, problem: problem}, unquote(clean_params)}, unquote(Macro.Env.location(caller))}
+            {__MODULE__.unquote(spec_fun_name(name, arity))(), {:param_error,
+             %{index: index, problem: problem}, unquote(clean_params)}, unquote(Macro.Env.location(caller))}}
       end
     end
   end
@@ -234,8 +234,8 @@ defmodule TypeCheck.Spec do
 
         {:error, problem} ->
           raise TypeCheck.TypeError,
-                {__MODULE__.unquote(spec_fun_name(name, arity))(), :return_error,
-                 %{problem: problem, arguments: unquote(clean_params)}, var!(super_result, nil)}
+                {{__MODULE__.unquote(spec_fun_name(name, arity))(), {:return_error,
+                 %{problem: problem, arguments: unquote(clean_params)}, var!(super_result, nil)}}
       end
     end
   end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -234,7 +234,7 @@ defmodule TypeCheck.Spec do
 
         {:error, problem} ->
           raise TypeCheck.TypeError,
-                {{__MODULE__.unquote(spec_fun_name(name, arity))(), {:return_error,
+                {__MODULE__.unquote(spec_fun_name(name, arity))(), {:return_error,
                  %{problem: problem, arguments: unquote(clean_params)}, var!(super_result, nil)}}
       end
     end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -198,7 +198,7 @@ defmodule TypeCheck.Spec do
       with unquote_splicing(paired_params) do
         # Run actual code
       else
-        {{:error, problem}, index, param_type} ->
+        {{:error, problem}, index} ->
           raise TypeCheck.TypeError,
           {
             {__MODULE__.unquote(spec_fun_name(name, arity))(), :param_error,
@@ -213,7 +213,7 @@ defmodule TypeCheck.Spec do
     # {file, line} = location
     quote generated: true, location: :keep do
       [
-        {{:ok, _bindings, altered_param}, _index, _param_type} <- {unquote(impl), unquote(index), unquote(Macro.escape(param_type))},
+        {{:ok, _bindings, altered_param}, _index} <- {unquote(impl), unquote(index)},
         clean_param = altered_param
        ]
     end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -200,10 +200,10 @@ defmodule TypeCheck.Spec do
         # Run actual code
       else
         {{:error, problem}, index} ->
-          raise TypeCheck.TypeError,
-          {
-            {__MODULE__.unquote(spec_fun_name(name, arity))(), {:param_error,
-             %{index: index, problem: problem}, unquote(clean_params)}, unquote(Macro.Env.location(caller))}}
+          type = __MODULE__.unquote(spec_fun_name(name, arity))()
+          problem_tuple = {:param_error, %{index: index, problem: problem}, unquote(clean_params)}
+          location = unquote(Macro.Env.location(caller))
+          raise TypeCheck.TypeError, {type, {problem_tuple, location}}
       end
     end
   end
@@ -220,7 +220,7 @@ defmodule TypeCheck.Spec do
     end
   end
 
-  defp return_check_code(name, arity, clean_params, return_type, _caller, _location) do
+  defp return_check_code(name, arity, clean_params, return_type, caller, _location) do
     return_code_check =
       TypeCheck.Protocols.ToCheck.to_check(return_type, Macro.var(:super_result, nil))
 
@@ -233,9 +233,10 @@ defmodule TypeCheck.Spec do
           altered_return_value
 
         {:error, problem} ->
-          raise TypeCheck.TypeError,
-                {__MODULE__.unquote(spec_fun_name(name, arity))(), {:return_error,
-                 %{problem: problem, arguments: unquote(clean_params)}, var!(super_result, nil)}}
+          type = __MODULE__.unquote(spec_fun_name(name, arity))()
+          problem_tuple = {:return_error, %{problem: problem, arguments: unquote(clean_params)}, var!(super_result, nil)}
+          location = unquote(Macro.Env.location(caller))
+          raise TypeCheck.TypeError, {type, {problem_tuple, location}}
       end
     end
   end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -12,8 +12,8 @@ defmodule TypeCheck.Spec do
     use TypeCheck
     alias TypeCheck.DefaultOverrides.String
     @type! t() :: %__MODULE__{name: String.t(), param_types: list(TypeCheck.Type.t()), return_type: TypeCheck.Type.t(), location: [] | list({:file, String.t()} | {:line, non_neg_integer()})}
-    @type! problem_tuple :: {t(), :param_error, %{index: non_neg_integer(), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, list(any())}
-    | {t(), :return_error, %{arguments: list(term()), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, list(any())}
+    @type! problem_tuple :: {:param_error, %{index: non_neg_integer(), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, list(any())}
+    | {:return_error, %{arguments: list(term()), problem: lazy(TypeCheck.TypeError.Formatter.problem_tuple())}, list(any())}
   end
 
   defp spec_fun_name(function, arity) do

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -113,8 +113,8 @@ defmodule TypeCheck.Spec do
         # import TypeCheck.Builtin
         %TypeCheck.Spec{
           name: unquote(name),
-          param_types: unquote(Macro.escape(param_types)),
-          return_type: unquote(Macro.escape(return_type)),
+          param_types: unquote(TypeCheck.Internals.Escaper.escape(param_types)),
+          return_type: unquote(TypeCheck.Internals.Escaper.escape(return_type)),
           location: {unquote(file), unquote(line)}
         }
       end

--- a/lib/type_check/spec.ex
+++ b/lib/type_check/spec.ex
@@ -106,6 +106,7 @@ defmodule TypeCheck.Spec do
   @doc false
   def create_spec_def(name, arity, param_types, return_type, {file, line}) do
     spec_fun_name = spec_fun_name(name, arity)
+    escaped_param_types = Enum.map(param_types, &TypeCheck.Internals.Escaper.escape/1)
 
     quote generated: true, location: :keep do
       @doc false
@@ -113,7 +114,7 @@ defmodule TypeCheck.Spec do
         # import TypeCheck.Builtin
         %TypeCheck.Spec{
           name: unquote(name),
-          param_types: unquote(TypeCheck.Internals.Escaper.escape(param_types)),
+          param_types: unquote(escaped_param_types),
           return_type: unquote(TypeCheck.Internals.Escaper.escape(return_type)),
           location: {unquote(file), unquote(line)}
         }

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -64,6 +64,70 @@ defmodule TypeCheck.TypeError do
     exception({problem_tuple, []})
   end
 
+  @simple_problems ~w[no_match not_same_value not_a_map not_a_list missing_keys superfluous_keys different_length different_size not_an_integer not_in_range wrong_size]a
+
+  def hydrate_problem_tuple(s = %TypeCheck.Type.StreamData{}, problem_tuple) do
+    hydrate_problem_tuple(s.type, problem_tuple)
+  end
+
   def hydrate_problem_tuple(s, problem_tuple) do
+    case problem_tuple do
+      {simple, meta, param} when simple in @simple_problems -> {s, simple, meta, param}
+      {:value_error, meta, param} ->
+        # TODO CompoundFixedMap
+        s2 = s.keypairs[meta.key]
+        meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+        {s, :value_error, meta2, param}
+      {:key_error, meta, param} ->
+        s2 = meta.key
+        meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+        {s, :key_error, meta2, param}
+      {:element_error, meta, param} -> # Handles both fixed_list and fixed_tuple
+        case s do
+          %TypeCheck.Builtin.List{} ->
+            s2 = s.element_type
+            meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+            {s, :element_error, meta2, param}
+          %TypeCheck.Builtin.MaybeImproperList{} ->
+            s2 = s.element_type
+            meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+            {s, :element_error, meta2, param}
+          %TypeCheck.Builtin.FixedList{} ->
+            s2 = Enum.at(s.element_types, meta.index)
+            meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+            {s, :element_error, meta2, param}
+          %TypeCheck.Builtin.FixedTuple{} ->
+            s2 = Enum.at(s.element_types, meta.index)
+            meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+            {s, :element_error, meta2, param}
+        end
+      {:terminator_error, meta, param} ->
+        s2 = s.terminator_type
+        meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+        {:terminator_error, meta2, param}
+      {:named_type, meta, param} ->
+        s2 = s.type
+        meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+        {:named_type, meta2, param}
+      {:all_failed, meta, param} ->
+        hydrated_problems =
+          Enum.zip(s.choices, meta.problems)
+          |> Enum.map(fn s2, problem ->
+            hydrate_problem_tuple(s2, problem)
+          end)
+        meta2 = put_in(meta.problems, hydrated_problems)
+        {:all_failed, meta2, param}
+      {:return_error, meta, param} ->
+        s2 = s.return_type
+        meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+        {s, :return_error, meta2, param}
+      {:param_error, meta, param} ->
+        s2 = Enum.at(s.param_types, meta.index)
+        meta2 = update_in(meta.problem, &hydrate_problem_tuple(s2, &1))
+        {s, :param_error, meta2, param}
+      other ->
+        IO.warn("TODO: #{inspect({s, problem_tuple})}")
+        other
+    end
   end
 end

--- a/lib/type_check/type_error.ex
+++ b/lib/type_check/type_error.ex
@@ -63,4 +63,7 @@ defmodule TypeCheck.TypeError do
   def exception(problem_tuple) do
     exception({problem_tuple, []})
   end
+
+  def hydrate_problem_tuple(s, problem_tuple) do
+  end
 end

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -1,16 +1,20 @@
 defmodule TypeCheck.TypeError.DefaultFormatter do
   @behaviour TypeCheck.TypeError.Formatter
 
-  @spec format(TypeCheck.TypeError.problem_tuple(), TypeCheck.TypeError.location()) :: String.t()
   def format(problem_tuple, location \\ []) do
-    res =
-      do_format(problem_tuple)
-      |> indent() # Ensure we start with four spaces, which multi-line exception pretty-printing expects
-      |> indent()
-
-    location_string(location) <> res
-    |> String.trim()
+    inspect(problem_tuple)
   end
+
+  # @spec format(TypeCheck.TypeError.problem_tuple(), TypeCheck.TypeError.location()) :: String.t()
+  # def format(problem_tuple, location \\ []) do
+  #   res =
+  #     do_format(problem_tuple)
+  #     |> indent() # Ensure we start with four spaces, which multi-line exception pretty-printing expects
+  #     |> indent()
+
+  #   location_string(location) <> res
+  #   |> String.trim()
+  # end
 
   defp location_string([]), do: ""
   defp location_string(location) do

--- a/lib/type_check/type_error/default_formatter.ex
+++ b/lib/type_check/type_error/default_formatter.ex
@@ -1,20 +1,20 @@
 defmodule TypeCheck.TypeError.DefaultFormatter do
   @behaviour TypeCheck.TypeError.Formatter
 
-  def format(problem_tuple, location \\ []) do
-    inspect(problem_tuple)
-  end
-
-  # @spec format(TypeCheck.TypeError.problem_tuple(), TypeCheck.TypeError.location()) :: String.t()
   # def format(problem_tuple, location \\ []) do
-  #   res =
-  #     do_format(problem_tuple)
-  #     |> indent() # Ensure we start with four spaces, which multi-line exception pretty-printing expects
-  #     |> indent()
-
-  #   location_string(location) <> res
-  #   |> String.trim()
+  #   inspect(problem_tuple)
   # end
+
+  @spec format(TypeCheck.TypeError.problem_tuple(), TypeCheck.TypeError.location()) :: String.t()
+  def format(problem_tuple, location \\ []) do
+    res =
+      do_format(problem_tuple)
+      |> indent() # Ensure we start with four spaces, which multi-line exception pretty-printing expects
+      |> indent()
+
+    location_string(location) <> res
+    |> String.trim()
+  end
 
   defp location_string([]), do: ""
   defp location_string(location) do

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule TypeCheck.MixProject do
       ],
       # main: "TypeCheck",
       groups_for_modules: [
-        Main: [TypeCheck, TypeCheck.Macros, TypeCheck.Type, TypeCheck.Spec, TypeCheck.Options, TypeCheck.ExUnit, TypeCheck.External],
+        Main: [TypeCheck, TypeCheck.Macros, TypeCheck.Type, TypeCheck.Spec, TypeCheck.Options, TypeCheck.ExUnit, TypeCheck.External, TypeCheck.Defstruct],
         "Errors and Formatting them": ~r"^TypeCheck.TypeError",
         "Property Testing": ~r"^TypeCheck.Type.StreamData",
         "Builtin Types": ~r"^TypeCheck.Builtin",


### PR DESCRIPTION
Fixes #110 

- [x] Instead of compiling the type-datastructure of the current error at each of the error responses, rebuild it once we create an exception from it from the outside in.
- [ ] Reconsider the type definitions of all the `problem_tuple` types. One approach might be to compile all module atom names, so we still have a stricter way to disambugate particular problem_tuples in the formatter and for data generation?
- [ ] Fix the tests. Quite a challenge :sweat_smile: 

The example code of the example now results in an Erlang core module of only ~138MB large, and compiles in roughly 15s on my local computer. (On faster computers, it probably will be sub-10s). I think this is as far as we can push this, without moving away from compiling all checks inline (which is out of scope for now, although it makes sense to add this in a future version.)