### PR TITLE
New regex generator

### DIFF
--- a/lib/type_check/default_overrides/regex.ex
+++ b/lib/type_check/default_overrides/regex.ex
@@ -1,9 +1,32 @@
 defmodule TypeCheck.DefaultOverrides.Regex do
   use TypeCheck
-  @type! t() :: %Elixir.Regex{
-    opts: binary(),
-    re_pattern: term(),
-    re_version: term(),
-    source: binary()
-  }
+  import TypeCheck.Type.StreamData
+  @type! t() :: wrap_with_gen(
+      %Elixir.Regex{
+        opts: binary(),
+        re_pattern: term(),
+        re_version: term(),
+        source: binary()
+      },
+      &TypeCheck.DefaultOverrides.Regex.regex_gen/0
+    )
+
+  if Code.ensure_loaded?(StreamData) do
+    def regex_gen do
+      :ascii
+      |> StreamData.string(min_length: 1)
+      |> StreamData.map(&Regex.compile/1)
+      # filtering here is SLOW, but a faster solution
+      # would be significntly more complex
+      |> StreamData.filter(fn
+        {:ok, _} -> true
+        {:error, _} -> false
+      end)
+      |> StreamData.map(fn {:ok, re} -> re end)
+    end
+  else
+    def regex_gen do
+      raise TypeCheck.CompileError, "This function requires the optional dependency StreamData."
+    end
+  end
 end


### PR DESCRIPTION
fixes #133 

the new generator works by creating a random ascii string and trying to compile it. if it compiles successfully, its emitted.

this works but has some drawbacks:
- this can be very slow
- if 25 strings fail to compile in a row, the generator raises
- it does not check unicode regexes

in my testing, a spectest with one regex to generate took 300-700ms, and i have not seen it actually generate 25 invalid strings in a row


an alternative implementation which knew regex syntax would be faster and not have the filter drawback, but it would also be _significantly_ more complex and would need to be updated to match erlang's `:re` in case it ever changed