### PR TITLE
fix compilation error

### DIFF
--- a/lib/type_check/options.ex
+++ b/lib/type_check/options.ex
@@ -77,6 +77,8 @@ defmodule TypeCheck.Options do
   for all added `@spec`s, as well as `TypeCheck.conforms/3`/`TypeCheck.conforms?/3`/`TypeCheck.conforms!/3` calls.
   """
 
+  defstruct [overrides: [], default_overrides: true, enable_runtime_checks: true, debug: false]
+
   if_recompiling? do
     use TypeCheck
 
@@ -106,8 +108,6 @@ defmodule TypeCheck.Options do
       debug: boolean(),
     }
   end
-
-  defstruct [overrides: [], default_overrides: true, enable_runtime_checks: true, debug: false]
 
   def new() do
     %__MODULE__{overrides: default_overrides()}


### PR DESCRIPTION
Running mix compile after adding type_check as a dep to a new Phoenix (v1.16.11) project with Elixir v1.14 results in the following error:

````
==> type_check
Compiling 122 files (.ex)

== Compilation error in file lib/type_check/internals/bootstrap.ex ==
** (CompileError) lib/type_check/options.ex:92: 
Could not look up default fields for struct type %TypeCheck.Options{
  overrides: type_overrides(),
  default_overrides: boolean(),
  enable_runtime_checks: boolean(),
  debug: boolean()
}.
This usually means that the type is used in the same module
as the `defstruct`, but before it.

Try changing e.g.
```
@type! t() :: %__MODULE__{}
defstruct [:some, :fields]
```

to:
```
defstruct [:some, :fields]
@type! t() :: %__MODULE__{}
```

See https://github.com/Qqwy/elixir-type_check/issues/83
for more information.

    lib/type_check/internals/pre_expander.ex:323: TypeCheck.Internals.PreExpander.rewrite_struct/4
    lib/type_check/macros.ex:508: TypeCheck.Macros.define_type/3
    lib/type_check/options.ex:92: (module)
    lib/type_check/internals/bootstrap.ex:12: (file)
    (elixir 1.14.0) lib/kernel/parallel_compiler.ex:346: anonymous fn/5 in Kernel.ParallelCompiler.spawn_workers/7
could not compile dependency :type_check, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile type_check", update it with "mix deps.update type_check" or clean it with "mix deps.clean type_check"
````

The issue was fixed by moving `defstruct` before `@type!` instead of after it.