### PR TITLE
Elixir 1.14 compatibility

### DIFF
--- a/lib/type_check/builtin/compound_fixed_map.ex
+++ b/lib/type_check/builtin/compound_fixed_map.ex
@@ -70,12 +70,22 @@ defmodule TypeCheck.Builtin.CompoundFixedMap do
       |> color(:map, opts)
     end
 
+    if function_exported?(Macro, :inspect_atom, 2) do
+      # Elixir 1.14+
+      defp inspect_as_key(key) do
+        Macro.inspect_atom(:key, key)
+      end
+    else
+      # Legacy Elixir
+      defdelegate inspect_as_key(key), to: Code.Identifier
+    end
+
     defp to_map_kv({key, value_type}, opts) do
       import Inspect.Algebra, only: [color: 3, concat: 2, to_doc: 2]
       value_doc = TypeCheck.Protocols.Inspect.inspect(value_type, opts)
 
       if non_module_atom?(key) do
-        key = color(Code.Identifier.inspect_as_key(key), :atom, opts)
+        key = color(inspect_as_key(key), :atom, opts)
         concat(key, concat(" ", value_doc))
       else
         sep = color(" =>", :map, opts)

--- a/lib/type_check/internals/parser.ex
+++ b/lib/type_check/internals/parser.ex
@@ -133,10 +133,17 @@ defmodule TypeCheck.Internals.Parser do
       {Date, :diff, [1, 2]}
   """
   @spec ast_to_mfa(Macro.t()) :: {module(), atom(), [Macro.t()]} | {:error, String.t()}
+  # Elixir 1.13- AST for imported function:
   def ast_to_mfa({func, [context: _, import: module], args}) do
     {module, func, args}
   end
 
+  # Elixir 1.14 AST for imported function:
+  def ast_to_mfa({func, [context: _, imports: [{1, module}]], args}) do
+    {module, func, args}
+  end
+
+  # AST for exported function:
   def ast_to_mfa({target, _, args}) do
     case target do
       {:., _, [{:__aliases__, [alias: false], [mod]}, func]} -> {elixir_module(mod), func, args}

--- a/test/type_check/internals/parser_test.exs
+++ b/test/type_check/internals/parser_test.exs
@@ -1,6 +1,6 @@
 defmodule TypeCheck.Internals.ParserTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   doctest TypeCheck.Internals.Parser
 
   alias TypeCheck.Internals.Parser


### PR DESCRIPTION
Hi! I was curious to try this on our codebase but ran into issues as we're already using Elixir 1.14

This fixes the two incompatibilities with Elixir 1.14:

* `Code.Identifier.inspect_as_key` was removed in Elixir 1.14
* AST for imported functions was changed in Elixir 1.14

It also resolves an issue when running the tests by disabling async mode for the parser tests.

~It also includes #144 (typo in commit message fixed)~ Ah! Already merged 👍 