### PR TITLE
Restore async testing

### DIFF
--- a/test/type_check/internals/parser_test.exs
+++ b/test/type_check/internals/parser_test.exs
@@ -1,6 +1,6 @@
 defmodule TypeCheck.Internals.ParserTest do
   @moduledoc false
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest TypeCheck.Internals.Parser
 
   alias TypeCheck.Internals.Parser
@@ -101,6 +101,7 @@ defmodule TypeCheck.Internals.ParserTest do
       {:module, _, bytecode, _} =
         defmodule TypespecSample do
           @moduledoc false
+          @compile :debug_info
           unquote(block)
           def f(a), do: a
         end


### PR DESCRIPTION
This is the most efficient way of doing things, as it keeps not generating `debug_info` for the rest of the debug code