### PR TITLE
152 auto required map keys

### DIFF
--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -262,6 +262,8 @@ defmodule TypeCheck.Internals.PreExpander do
               # Otherwise, it is shorthand for `required(key) => value`
               req_key = rewrite(key_type, env, options)
               req_value = rewrite(value_type, env, options)
+              # IO.inspect({req_key, req_value}, label: :asdf)
+
               case req_key do
                   # `required(literal(key))`
                 {{:., _, [{:__aliases__, _, [:TypeCheck, :Builtin]}, :literal]}, _, [fixed_key]} ->

--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -244,19 +244,32 @@ defmodule TypeCheck.Internals.PreExpander do
             {{:required, _, [key_type]}, value_type}, acc ->
               req_key = rewrite(key_type, env, options)
               req_value = rewrite(value_type, env, options)
-            case req_key do
-                # `required(literal(key))`
-              {{:., _, [{:__aliases__, _, [:TypeCheck, :Builtin]}, :literal]}, _, [fixed_key]} ->
-                update_in(acc.fixed, fn fixeds -> [{fixed_key, req_value} | fixeds] end)
-              _ ->
-                update_in(acc.required, fn requireds -> [{req_key, req_value} | requireds] end)
-            end
+              case req_key do
+                  # `required(literal(key))`
+                {{:., _, [{:__aliases__, _, [:TypeCheck, :Builtin]}, :literal]}, _, [fixed_key]} ->
+                  update_in(acc.fixed, fn fixeds -> [{fixed_key, req_value} | fixeds] end)
+                _ ->
+                  update_in(acc.required, fn requireds -> [{req_key, req_value} | requireds] end)
+              end
             {{:optional, _, [key_type]}, value_type}, acc->
               opt = {rewrite(key_type, env, options), rewrite(value_type, env, options)}
               update_in(acc.optional, fn optionals -> [opt | optionals] end)
-            {key, value_type}, acc ->
+            {key, value_type}, acc when is_atom(key) or is_integer(key) or is_binary(key) ->
+              # A basic fixed key for a static 'struct like' map
               fix = {key, rewrite(value_type, env, options)}
               update_in(acc.fixed, fn fixeds -> [fix | fixeds] end)
+            {key_type, value_type}, acc ->
+              # Otherwise, it is shorthand for `required(key) => value`
+              req_key = rewrite(key_type, env, options)
+              req_value = rewrite(value_type, env, options)
+              case req_key do
+                  # `required(literal(key))`
+                {{:., _, [{:__aliases__, _, [:TypeCheck, :Builtin]}, :literal]}, _, [fixed_key]} ->
+                  update_in(acc.fixed, fn fixeds -> [{fixed_key, req_value} | fixeds] end)
+                _ ->
+                  update_in(acc.required, fn requireds -> [{req_key, req_value} | requireds] end)
+              end
+
             other, _acc ->
               raise """
               Unknown syntax in map type literal: #{inspect(other)}.

--- a/test/support/map_key_syntax_example.ex
+++ b/test/support/map_key_syntax_example.ex
@@ -1,10 +1,15 @@
 defmodule MapKeySyntaxExample do
+  # Ensures this module is only compiled after TypeCheck's recompilation.
+  # This is (only) necessary because this module is in the same project as TypeCheck's source itself.
+  # Without this, using type overrides such as `String.t()` would not work.
+  require TypeCheck.DefaultOverrides
+
   defstruct [:name]
   use TypeCheck
-  @type! t :: %__MODULE__{name: binary()}
+  @type! t :: %__MODULE__{name: String.t()}
 
   # binary() should be supported as map key
   # and be considered the same as `required(binary())`
-  @spec! example(%{binary() => any} | t()) :: t()
+  @spec! example(%{String.t() => any} | t()) :: t()
   def example(%__MODULE__{} = struct), do: struct
 end

--- a/test/support/map_key_syntax_example.ex
+++ b/test/support/map_key_syntax_example.ex
@@ -1,10 +1,10 @@
 defmodule MapKeySyntaxExample do
   defstruct [:name]
   use TypeCheck
-  @type! t :: %__MODULE__{name: String.t()}
+  @type! t :: %__MODULE__{name: binary()}
 
-  # String.t() should be supported as map key
-  # and be considered the same as `required(String.t())`
-  @spec! example(%{String.t() => any} | t()) :: t()
+  # binary() should be supported as map key
+  # and be considered the same as `required(binary())`
+  @spec! example(%{binary() => any} | t()) :: t()
   def example(%__MODULE__{} = struct), do: struct
 end

--- a/test/support/map_key_syntax_example.ex
+++ b/test/support/map_key_syntax_example.ex
@@ -12,4 +12,5 @@ defmodule MapKeySyntaxExample do
   # and be considered the same as `required(binary())`
   @spec! example(%{String.t() => any} | t()) :: t()
   def example(%__MODULE__{} = struct), do: struct
+  def example(map), do: %__MODULE__{name: inspect(map)}
 end

--- a/test/support/map_key_syntax_example.ex
+++ b/test/support/map_key_syntax_example.ex
@@ -1,0 +1,10 @@
+defmodule MapKeySyntaxExample do
+  defstruct [:name]
+  use TypeCheck
+  @type! t :: %__MODULE__{name: String.t()}
+
+  # String.t() should be supported as map key
+  # and be considered the same as `required(String.t())`
+  @spec! example(%{String.t() => any} | t()) :: t()
+  def example(%__MODULE__{} = struct), do: struct
+end

--- a/test/type_check_test.exs
+++ b/test/type_check_test.exs
@@ -121,4 +121,14 @@ defmodule TypeCheckTest do
       assert t2_str == "t() :: t(true | false)"
     end
   end
+
+  test "Usage of shorthand map key syntax (`String.t()` == `required(String.t())`) is possible (regression test for #152)" do
+    # Depends on the example in `support/map_key_syntax_example.ex`
+    assert MapKeySyntaxExample.example(%{"foo" => 10}) ==
+             %MapKeySyntaxExample{
+               name: "%{\"foo\" => 10}"
+             }
+
+    assert_raise(TypeCheck.TypeError, fn -> MapKeySyntaxExample.example(10) end)
+  end
 end


### PR DESCRIPTION
- [x] Basic fix to ensure that `%{foo => bar}` is translated to `%{required(foo) => bar}` if `foo` is not a static atom, integer or binary value.
- [x] Basic example that compiles in the test suite only if this fix is in place.
- [x] Use the basic example in tests.

Fixes #152
Fixes #159 