### PR TITLE
Fix 'Enumerable not implemented' error when struct is passed to map check

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Details:
 - 0.13.0 - 
   - Additions:
     - Support for maps with multiple optional atom keys. Thank you very much, @dvic! (c.f. #165)
+  - Fixes:
+    - Fixes 'Enumerable not implemented' crash when passing a struct to a type expecting a fixed map. (c.f. #161)
 - 0.12.4 - 
   - Fixes:
     - Allow syntax `%{String.t() => any()}` as shorthand for `%{required(String.t()) => any()}`. (c.f. #152)

--- a/lib/type_check/builtin/map.ex
+++ b/lib/type_check/builtin/map.ex
@@ -56,6 +56,8 @@ defmodule TypeCheck.Builtin.Map do
 
         res =
           orig_param
+          # :maps.to_list is needed so a struct without an Enumerable impl does not crash this code:
+          |> :maps.to_list()
           |> Enum.reduce_while({:ok, [], []}, fn {key, value}, {:ok, bindings, altered_param} ->
             var!(single_field_key, unquote(__MODULE__)) = key
             var!(single_field_value, unquote(__MODULE__)) = value

--- a/test/support/enumerable_not_implemented_example.ex
+++ b/test/support/enumerable_not_implemented_example.ex
@@ -5,7 +5,7 @@ defmodule EnumerableNotImplementedExample do
   require TypeCheck.DefaultOverrides
 
   defstruct [:name]
-  use TypeCheck, enable_runtime_checks: Mix.env() != :prod
+  use TypeCheck
   @type! t :: %__MODULE__{name: String.t()}
 
   @spec! hello(%{String.t() => any} | t()) :: atom

--- a/test/support/enumerable_not_implemented_example.ex
+++ b/test/support/enumerable_not_implemented_example.ex
@@ -1,0 +1,13 @@
+defmodule EnumerableNotImplementedExample do
+  # Ensures this module is only compiled after TypeCheck's recompilation.
+  # This is (only) necessary because this module is in the same project as TypeCheck's source itself.
+  # Without this, using type overrides such as `String.t()` would not work.
+  require TypeCheck.DefaultOverrides
+
+  defstruct [:name]
+  use TypeCheck, enable_runtime_checks: Mix.env() != :prod
+  @type! t :: %__MODULE__{name: String.t()}
+
+  @spec! hello(%{String.t() => any} | t()) :: atom
+  def hello(_struct), do: :ok
+end

--- a/test/type_check/builtin/fixed_map_test.exs
+++ b/test/type_check/builtin/fixed_map_test.exs
@@ -44,7 +44,7 @@ defmodule TypeCheck.Builtin.FixedMapTest do
              TypeCheck.conforms(%{foo: "bar", key: "hello"}, %{key: String.t()})
   end
 
-  test "Checkings structs does not get a 'protocol Enumerable not implemented' (Regression #161)" do
+  test "Checkings structs inside a union that also allows maps does not get a 'protocol Enumerable not implemented' (Regression #161)" do
     assert EnumerableNotImplementedExample.hello(%{"a" => :b}) == :ok
 
     assert EnumerableNotImplementedExample.hello(%EnumerableNotImplementedExample{name: "X"}) ==

--- a/test/type_check/builtin/fixed_map_test.exs
+++ b/test/type_check/builtin/fixed_map_test.exs
@@ -43,4 +43,11 @@ defmodule TypeCheck.Builtin.FixedMapTest do
     assert {:error, %TypeCheck.TypeError{raw: {_, :superfluous_keys, %{keys: [:foo]}, _}}} =
              TypeCheck.conforms(%{foo: "bar", key: "hello"}, %{key: String.t()})
   end
+
+  test "Checkings structs does not get a 'protocol Enumerable not implemented' (Regression #161)" do
+    assert EnumerableNotImplementedExample.hello(%{"a" => :b}) == :ok
+
+    assert EnumerableNotImplementedExample.hello(%EnumerableNotImplementedExample{name: "X"}) ==
+             :ok
+  end
 end


### PR DESCRIPTION
Fixes #161 