### PR TITLE
Enable usage of TypeCheck in non-Elixir-modulename modules

### DIFF
--- a/lib/type_check/internals/helper.ex
+++ b/lib/type_check/internals/helper.ex
@@ -39,4 +39,33 @@ defmodule TypeCheck.Internals.Helper do
       Macro.Env.fetch_alias(env, single_atom)
     end
   end
+
+  @doc """
+  Module.split/1 raises on non-Elixir module names.
+  (atoms or binaries that do not start with `Elixir.')
+
+  This is a safe variant to allow TypeCheck to be used in modules
+  that do not follow this convention (like `:my_module_name`),
+  which is sometimes done to for instance expose
+  an Erlang-ergonomic interface to an Elixir library.
+  c.f. [#174](https://github.com/Qqwy/elixir-type_check/issues/174)
+  """
+  @spec module_split_safe(module | String.t()) :: [String.t(), ...]
+  def module_split_safe(module)
+
+  def module_split_safe(module) when is_atom(module) do
+    module_split_safe(Atom.to_string(module), _original = module)
+  end
+
+  def module_split_safe(module) when is_binary(module) do
+    module_split_safe(module, _original = module)
+  end
+
+  defp module_split_safe("Elixir." <> name, _original) do
+    String.split(name, ".")
+  end
+
+  defp module_split_safe(_module, original) do
+    original
+  end
 end

--- a/lib/type_check/macros.ex
+++ b/lib/type_check/macros.ex
@@ -623,7 +623,7 @@ defmodule TypeCheck.Macros do
     pretty_module_name = Keyword.get(overridden_modules, module_name, module_name)
 
     pretty_module_name =
-      case Module.split(pretty_module_name) do
+      case TypeCheck.Internals.Helper.module_split_safe(pretty_module_name) do
         ["TypeCheck", "DefaultOverrides" | rest] ->
           Module.concat(rest)
 

--- a/test/type_check/spec_test.exs
+++ b/test/type_check/spec_test.exs
@@ -20,4 +20,18 @@ defmodule TypeCheck.SpecTest do
       def f(), do: 1
     end
   end
+
+  test "Using TypeCheck in non-Elixir modules (lower case atoms) is OK (regression test against ##174)" do
+    defmodule :my_module_name do
+      use TypeCheck
+
+      @type! str :: String.t()
+
+      @spec! hello(str()) :: :ok
+      def hello(name) do
+        IO.puts("Hello #{name}!")
+        :ok
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add a non-raising version of Module.split to TypeCheck.Helpersand use this when generating the spec-specific module. This enables usage of TypeCheck in non-Elixir-modulename modules like `:my_module_name`

Fixes #174