### PR TITLE
add README link to Marten's ElixirConf EU 2022 presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ by adding `type_check` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:type_check, "~> 0.12.1"},
+    {:type_check, "~> 0.13.3"},
     # To allow spectesting and property-testing data generators (optional):
     {:stream_data, "~> 0.5.0", only: :test}, 
   ]

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ end
 
 The documentation can be found at [https://hexdocs.pm/type_check](https://hexdocs.pm/type_check).
 
-Marten Wijnja's _ElixirConf EU 2022_ presentation "TypeCheck Effortless Runtime Type Checking" is viewable [here](https://www.youtube.com/watch?v=7ykfO2tBwYw).
+Marten Wijnja's _ElixirConf EU 2022_ presentation "TypeCheck: Effortless Runtime Type Checking" is viewable [here](https://www.youtube.com/watch?v=7ykfO2tBwYw).
 
 ### Formatter
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ end
 
 The documentation can be found at [https://hexdocs.pm/type_check](https://hexdocs.pm/type_check).
 
+Marten Wijnja's _ElixirConf EU 2022_ presentation "TypeCheck Effortless Runtime Type Checking" is viewable [here](https://www.youtube.com/watch?v=7ykfO2tBwYw).
+
 ### Formatter
 
 TypeCheck exports a couple of macros that you might want to use without parentheses. To make `mix format` respect this setting, add `import_deps: [:type_check]` to your `.formatter.exs` file.


### PR DESCRIPTION
* Add README link to Marten's ElixirConf EU 2022 presentation
* Update TypeCheck version in README from 0.12.1 to 0.13.3

(Thanks for this wonderful library!)