### PR TITLE
fix compilation on elixir 1.17.x

### DIFF
--- a/lib/type_check/internals/pre_expander.ex
+++ b/lib/type_check/internals/pre_expander.ex
@@ -89,7 +89,7 @@ defmodule TypeCheck.Internals.PreExpander do
 
       [{:->, _, args}] ->
         case args do
-          [[{:..., _, module}], return_type] when is_atom(module) ->
+          [[{:..., _, module}], return_type] when is_atom(module) or module == [] ->
             quote generated: true, location: :keep do
               TypeCheck.Builtin.function(unquote(rewrite(return_type, env, options)))
             end


### PR DESCRIPTION
fixes #190

this enables compilation on newer (1.17+) elixirs. i'm pretty unfamiliar with this code so there might be something obvious i'm missing about the implications of the change, so feel free to reject this if its not the right way to solve this.

locally, 6 tests are failing, but they appear to be unchanged vs main (checked with 1.17.2/OTP-27 and 1.16.3/OTP-26). most of these appear to be failing because they rely on small map ordering which changed with OTP 26